### PR TITLE
Wrapped links

### DIFF
--- a/db/10_create_wrapped_link.json
+++ b/db/10_create_wrapped_link.json
@@ -14,6 +14,7 @@
                     "name": "id",
                     "type": "varchar(64)",
                     "constraints": {
+                      "primaryKey": true,
                       "nullable": false
                     }
                   }

--- a/db/10_create_wrapped_link.json
+++ b/db/10_create_wrapped_link.json
@@ -1,0 +1,46 @@
+{
+  "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "10",
+        "author": "zach",
+        "changes": [
+          {
+            "createTable": {
+              "tableName": "wrapped_link",
+              "columns": [
+                {
+                  "column": {
+                    "name": "id",
+                    "type": "varchar(64)",
+                    "constraints": {
+                      "nullable": false
+                    }
+                  }
+                },
+                {
+                  "column": {
+                    "name": "contact_id",
+                    "type": "int",
+                    "constraints": {
+                      "nullable": false
+                    }
+                  }
+                },
+                {
+                  "column": {
+                    "name": "year",
+                    "type": "int",
+                    "constraints": {
+                      "nullable": false
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/db/changelog.json
+++ b/db/changelog.json
@@ -44,6 +44,11 @@
       "include": {
         "file": "9_create_contact_token.json"
       }
+    },
+    {
+      "include": {
+        "file": "10_create_wrapped_link.json"
+      }
     }
   ]
 }

--- a/src/main/kotlin/sh/zachwal/button/admin/AdminController.kt
+++ b/src/main/kotlin/sh/zachwal/button/admin/AdminController.kt
@@ -144,6 +144,16 @@ class AdminController @Inject constructor(
                                     }
                                 }
                             }
+                            h2 {
+                                +"Wrapped"
+                            }
+                            ul {
+                                li {
+                                    a(href = "/admin/wrapped") {
+                                        +"Wrapped"
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/src/main/kotlin/sh/zachwal/button/admin/AdminWrappedController.kt
+++ b/src/main/kotlin/sh/zachwal/button/admin/AdminWrappedController.kt
@@ -1,0 +1,131 @@
+package sh.zachwal.button.admin
+
+import com.google.inject.Inject
+import io.ktor.application.call
+import io.ktor.html.respondHtml
+import io.ktor.response.respondRedirect
+import io.ktor.routing.Routing
+import io.ktor.routing.get
+import io.ktor.routing.post
+import kotlinx.html.FormMethod
+import kotlinx.html.TBODY
+import kotlinx.html.a
+import kotlinx.html.body
+import kotlinx.html.div
+import kotlinx.html.form
+import kotlinx.html.h1
+import kotlinx.html.head
+import kotlinx.html.submitInput
+import kotlinx.html.tbody
+import kotlinx.html.td
+import kotlinx.html.th
+import kotlinx.html.thead
+import kotlinx.html.title
+import kotlinx.html.tr
+import sh.zachwal.button.controller.Controller
+import sh.zachwal.button.db.jdbi.WrappedLink
+import sh.zachwal.button.roles.adminRoute
+import sh.zachwal.button.shared_html.headSetup
+import sh.zachwal.button.shared_html.responsiveTable
+import sh.zachwal.button.wrapped.WrappedService
+
+@Controller
+class AdminWrappedController @Inject constructor(
+    private val wrappedService: WrappedService
+) {
+
+    private val cardClasses = "col-8 mt-4 h-100"
+
+    internal fun Routing.wrapped() {
+        adminRoute("/admin/wrapped") {
+            get {
+                val wrappedLinks = wrappedService.listWrappedLinks()
+
+                call.respondHtml {
+                    head {
+                        title {
+                            +"Wrapped"
+                        }
+                        headSetup()
+                    }
+                    body {
+                        div(classes = "container") {
+                            h1(classes = "mt-4 text-center") {
+                                a(href = "/admin/wrapped/generate") {
+                                    +"Generate Page"
+                                }
+                            }
+                            h1(classes = "mt-4 text-center") {
+                                +"Links"
+                            }
+                            div(classes = "row justify-content-center") {
+                                responsiveTable(classes = "m-2") {
+                                    thead {
+                                        tr {
+                                            th {
+                                                +"Wrapped Id"
+                                            }
+                                            th {
+                                                +"Year"
+                                            }
+                                            th {
+                                                +"Contact ID"
+                                            }
+                                        }
+                                    }
+                                    tbody {
+                                        wrappedLinks.forEach { wrappedLink ->
+                                            wrappedLinkRow(wrappedLink)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    internal fun Routing.wrappedGenerate() {
+        adminRoute("/admin/wrapped/generate") {
+            get {
+                call.respondHtml {
+                    head {
+                        title {
+                            +"Wrapped Link Generation"
+                        }
+                        headSetup()
+                    }
+                    body {
+                        form(method = FormMethod.post, classes = "mb-1") {
+                            submitInput(classes = "btn btn-primary") {
+                                value = "Generate Links"
+                            }
+                        }
+                    }
+                }
+            }
+            post {
+                wrappedService.createWrappedLinks()
+                call.respondRedirect("/admin/wrapped")
+            }
+        }
+    }
+
+    private fun TBODY.wrappedLinkRow(wrappedLink: WrappedLink) {
+        tr {
+            th {
+                a(href = "/wrapped/${wrappedLink.year}/${wrappedLink.wrappedId}") {
+                    +"Link"
+                }
+            }
+            td {
+                +"${wrappedLink.year}"
+            }
+            td {
+                +"${wrappedLink.contactId}"
+            }
+        }
+    }
+}

--- a/src/main/kotlin/sh/zachwal/button/auth/contact/ContactTokenStore.kt
+++ b/src/main/kotlin/sh/zachwal/button/auth/contact/ContactTokenStore.kt
@@ -2,12 +2,11 @@ package sh.zachwal.button.auth.contact
 
 import org.slf4j.LoggerFactory
 import sh.zachwal.button.db.dao.ContactTokenDAO
-import java.security.SecureRandom
+import sh.zachwal.button.random.RandomStringGenerator
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.streams.toList
 
 // Custom class that stores a token -> contact mapping
 @Singleton
@@ -17,20 +16,10 @@ class ContactTokenStore @Inject constructor(
 
     private val logger = LoggerFactory.getLogger(ContactTokenStore::class.java)
 
-    private val secureRandom = SecureRandom()
-    private val chars = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-
-    private fun newToken(): String {
-        return secureRandom.ints(20, 0, chars.length).toList()
-            .map { randInt ->
-                chars[randInt]
-            }.fold(StringBuilder()) { sb, char ->
-                sb.append(char)
-            }.toString()
-    }
+    private val randomStringGenerator = RandomStringGenerator()
 
     fun createToken(contactId: Int): String {
-        val token = newToken()
+        val token = randomStringGenerator.newToken(20)
         val expiration = Instant.now().plus(7, ChronoUnit.DAYS)
         val contactToken = contactTokenDAO.createToken(token, contactId, expiration)
 

--- a/src/main/kotlin/sh/zachwal/button/db/dao/WrappedDAO.kt
+++ b/src/main/kotlin/sh/zachwal/button/db/dao/WrappedDAO.kt
@@ -1,7 +1,10 @@
 package sh.zachwal.button.db.dao
 
+import org.jdbi.v3.sqlobject.customizer.BindBean
 import org.jdbi.v3.sqlobject.statement.SqlQuery
+import org.jdbi.v3.sqlobject.statement.SqlUpdate
 import sh.zachwal.button.db.jdbi.Press
+import sh.zachwal.button.db.jdbi.WrappedLink
 import sh.zachwal.button.db.jdbi.WrappedRank
 import java.time.Instant
 
@@ -37,4 +40,38 @@ interface WrappedDAO {
         "select * from public.press where time > ? and time < ? and contact_id = ? order by time"
     )
     fun selectBetweenForContact(begin: Instant, end: Instant, contactId: Int): List<Press>
+
+    @SqlQuery(
+        """
+            select
+              distinct(c.id)
+            from 
+              contact c 
+              join press p on p.contact_id = c.id
+            where 
+              p.time >= ? and p.time < ?;
+        """
+    )
+    fun contactsWithPresses(fromInstant: Instant, toInstant: Instant): List<Int>
+
+    @SqlUpdate(
+        """
+            insert into public.wrapped_link
+            (id, contact_id, year)
+            values (:wrappedId, :contactId, :year)
+        """
+    )
+    fun insertWrappedLink(@BindBean wrappedLink: WrappedLink)
+
+    @SqlQuery(
+        """
+            select 
+              id as wrappedId,
+              year,
+              contact_id as contactId
+            from
+              wrapped_link;
+        """
+    )
+    fun wrappedLinks(): List<WrappedLink>
 }

--- a/src/main/kotlin/sh/zachwal/button/db/jdbi/WrappedLink.kt
+++ b/src/main/kotlin/sh/zachwal/button/db/jdbi/WrappedLink.kt
@@ -1,0 +1,15 @@
+package sh.zachwal.button.db.jdbi
+
+/**
+ * Stores the ID of a given Wrapped for some contact for some year.
+ *
+ * Contacts are sent a URL including this wrapped ID and use that to find
+ * their Wrapped.
+ *
+ * Wrapped IDs are random.
+ */
+data class WrappedLink constructor(
+    val wrappedId: String,
+    val year: Int,
+    val contactId: Int
+)

--- a/src/main/kotlin/sh/zachwal/button/random/RandomStringGenerator.kt
+++ b/src/main/kotlin/sh/zachwal/button/random/RandomStringGenerator.kt
@@ -1,0 +1,19 @@
+package sh.zachwal.button.random
+
+import java.security.SecureRandom
+import kotlin.streams.toList
+
+class RandomStringGenerator {
+
+    private val secureRandom = SecureRandom()
+    private val chars = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+    fun newToken(length: Long): String {
+        return secureRandom.ints(length, 0, chars.length).toList()
+            .map { randInt ->
+                chars[randInt]
+            }.fold(StringBuilder()) { sb, char ->
+                sb.append(char)
+            }.toString()
+    }
+}

--- a/src/main/kotlin/sh/zachwal/button/wrapped/WrappedController.kt
+++ b/src/main/kotlin/sh/zachwal/button/wrapped/WrappedController.kt
@@ -34,13 +34,6 @@ class WrappedController @Inject constructor(
             get {
                 val year = call.parameters.getOrFail(yearParam).toInt()
                 val wrappedId = call.parameters.getOrFail(wrappedIdParam)
-
-                // for testing
-//                if (wrappedId.toInt() !in setOf(1, 2, 3, 9)) {
-//                    call.respond(HttpStatusCode.NotFound, "Wrapped with id $wrappedId not found.")
-//                    return@get
-//                }
-
                 val wrapped = wrappedService.wrapped(year, wrappedId)
 
                 call.respondHtml {

--- a/src/main/kotlin/sh/zachwal/button/wrapped/WrappedController.kt
+++ b/src/main/kotlin/sh/zachwal/button/wrapped/WrappedController.kt
@@ -2,8 +2,6 @@ package sh.zachwal.button.wrapped
 
 import io.ktor.application.call
 import io.ktor.html.respondHtml
-import io.ktor.http.HttpStatusCode
-import io.ktor.response.respond
 import io.ktor.routing.Routing
 import io.ktor.routing.get
 import io.ktor.routing.route
@@ -38,10 +36,10 @@ class WrappedController @Inject constructor(
                 val wrappedId = call.parameters.getOrFail(wrappedIdParam)
 
                 // for testing
-                if (wrappedId.toInt() !in setOf(1, 2, 3, 9)) {
-                    call.respond(HttpStatusCode.NotFound, "Wrapped with id $wrappedId not found.")
-                    return@get
-                }
+//                if (wrappedId.toInt() !in setOf(1, 2, 3, 9)) {
+//                    call.respond(HttpStatusCode.NotFound, "Wrapped with id $wrappedId not found.")
+//                    return@get
+//                }
 
                 val wrapped = wrappedService.wrapped(year, wrappedId)
 

--- a/src/main/kotlin/sh/zachwal/button/wrapped/WrappedService.kt
+++ b/src/main/kotlin/sh/zachwal/button/wrapped/WrappedService.kt
@@ -3,6 +3,9 @@ package sh.zachwal.button.wrapped
 import io.ktor.features.NotFoundException
 import sh.zachwal.button.db.dao.ContactDAO
 import sh.zachwal.button.db.dao.WrappedDAO
+import sh.zachwal.button.db.jdbi.WrappedLink
+import sh.zachwal.button.random.RandomStringGenerator
+import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.Month
@@ -17,21 +20,63 @@ class WrappedService @Inject constructor(
     private val wrappedDAO: WrappedDAO
 ) {
 
-    fun createWrappedLinks() {
+    private val randomStringGenerator = RandomStringGenerator()
+    private fun startOfYearInstant(year: Int): Instant =
+        LocalDate.of(year, Month.JANUARY, 1)
+            .atStartOfDay(easternTime)
+            .toInstant()
 
+    private fun endOfYearInstant(year: Int): Instant =
+        LocalDate.of(year + 1, Month.JANUARY, 1)
+            .atStartOfDay(easternTime)
+            .toInstant()
+
+    fun createWrappedLinks() {
+        val year = LocalDate.now().year
+        val links = wrappedDAO.wrappedLinks()
+
+        if (links.any { it.year == year }) {
+            throw RuntimeException("Links have already been generated for $year!")
+        }
+
+        val contactIds = wrappedDAO.contactsWithPresses(
+            fromInstant = startOfYearInstant(year),
+            toInstant = endOfYearInstant(year)
+        )
+
+        contactIds.forEach { contactId ->
+            val wrappedId = randomStringGenerator.newToken(20)
+            val wrappedLink = WrappedLink(
+                wrappedId,
+                year,
+                contactId
+            )
+
+            wrappedDAO.insertWrappedLink(wrappedLink)
+        }
     }
 
+    fun listWrappedLinks(): List<WrappedLink> {
+        return wrappedDAO.wrappedLinks()
+    }
+
+    private val easternTime = ZoneId.of("America/New_York")
+
     fun wrapped(year: Int, id: String): Wrapped {
-        val contact = contactDAO.findContact(id.toInt()) ?: throw NotFoundException(
+        val wrappedLink = wrappedDAO.wrappedLinks()
+            .find { it.wrappedId == id }
+            ?: throw NotFoundException("Could not find Wrapped with id $id")
+
+        val contact = contactDAO.findContact(wrappedLink.contactId) ?: throw NotFoundException(
             "Could not " +
                 "find contact with id $id."
         )
 
-        val easternTime = ZoneId.of("America/New_York")
-        val start = LocalDate.of(year, Month.JANUARY, 1).atStartOfDay(easternTime).toInstant()
-        val end = LocalDate.of(year, Month.DECEMBER, 15).atStartOfDay(easternTime).toInstant()
-
-        val presses = wrappedDAO.selectBetweenForContact(start, end, id.toInt())
+        val presses = wrappedDAO.selectBetweenForContact(
+            begin = startOfYearInstant(year),
+            end = endOfYearInstant(year),
+            contactId = contact.id
+        )
         val countByDay = presses.groupBy {
             LocalDate.ofInstant(it.time, easternTime).dayOfWeek
         }
@@ -54,11 +99,9 @@ class WrappedService @Inject constructor(
         }
         val favoriteHourString = "$favoriteHour12Hour$favoriteHourAmPm"
 
-        val thisYear = LocalDate.of(year, 1, 1)
-        val nextYear = LocalDate.of(year + 1, 1, 1)
         val wrappedRanks = wrappedDAO.wrappedRanks(
-            fromInstant = thisYear.atStartOfDay(easternTime).toInstant(),
-            toInstant = nextYear.atStartOfDay(easternTime).toInstant()
+            fromInstant = startOfYearInstant(year),
+            toInstant = endOfYearInstant(year)
         )
         val wrappedRank = wrappedRanks.find { it.contactId == contact.id }!!
 

--- a/src/main/kotlin/sh/zachwal/button/wrapped/WrappedService.kt
+++ b/src/main/kotlin/sh/zachwal/button/wrapped/WrappedService.kt
@@ -17,6 +17,10 @@ class WrappedService @Inject constructor(
     private val wrappedDAO: WrappedDAO
 ) {
 
+    fun createWrappedLinks() {
+
+    }
+
     fun wrapped(year: Int, id: String): Wrapped {
         val contact = contactDAO.findContact(id.toInt()) ?: throw NotFoundException(
             "Could not " +

--- a/src/test/kotlin/sh/zachwal/button/wrapped/WrappedServiceTest.kt
+++ b/src/test/kotlin/sh/zachwal/button/wrapped/WrappedServiceTest.kt
@@ -7,6 +7,7 @@ import sh.zachwal.button.db.dao.ContactDAO
 import sh.zachwal.button.db.dao.WrappedDAO
 import sh.zachwal.button.db.jdbi.Contact
 import sh.zachwal.button.db.jdbi.Press
+import sh.zachwal.button.db.jdbi.WrappedLink
 import sh.zachwal.button.db.jdbi.WrappedRank
 import java.time.Instant
 import java.time.format.DateTimeFormatter
@@ -27,6 +28,11 @@ class WrappedServiceTest {
                 rank = 1,
                 percentile = 0.01
             )
+        )
+        every {
+            wrappedLinks()
+        } returns listOf(
+            WrappedLink("1", 2023, 1)
         )
     }
     private val contactDao: ContactDAO = mockk {


### PR DESCRIPTION
Generate non-guessable wrapped links rather than using guessable, incrementing contact ids. 

Store them in a database.

Retrieve them on loading the wrapped page.

Generate them and display them on an admin page.