### PR TITLE
Improve session length & logging of presses that trigger a notification

### DIFF
--- a/src/main/kotlin/sh/zachwal/button/App.kt
+++ b/src/main/kotlin/sh/zachwal/button/App.kt
@@ -11,6 +11,7 @@ import io.ktor.features.ContentNegotiation
 import io.ktor.features.DefaultHeaders
 import io.ktor.features.StatusPages
 import io.ktor.features.XForwardedHeaderSupport
+import io.ktor.features.maxAge
 import io.ktor.http.content.resources
 import io.ktor.http.content.static
 import io.ktor.jackson.jackson
@@ -42,6 +43,7 @@ import sh.zachwal.button.session.principals.ContactSessionPrincipal
 import sh.zachwal.button.session.principals.UserSessionPrincipal
 import sh.zachwal.button.users.UserService
 import kotlin.collections.set
+import kotlin.time.Duration.Companion.days
 import kotlin.time.ExperimentalTime
 
 fun main(args: Array<String>): Unit = io.ktor.server.netty.EngineMain.main(args)
@@ -97,6 +99,7 @@ fun Application.module(testing: Boolean = false) {
             cookie.httpOnly = true
             cookie.secure = config.env != "DEV"
             cookie.extensions["SameSite"] = "lax"
+            cookie.maxAge = 30.days
         }
     }
 

--- a/src/main/kotlin/sh/zachwal/button/auth/contact/ContactTokenStore.kt
+++ b/src/main/kotlin/sh/zachwal/button/auth/contact/ContactTokenStore.kt
@@ -20,7 +20,7 @@ class ContactTokenStore @Inject constructor(
 
     fun createToken(contactId: Int): String {
         val token = randomStringGenerator.newToken(20)
-        val expiration = Instant.now().plus(7, ChronoUnit.DAYS)
+        val expiration = Instant.now().plus(30, ChronoUnit.DAYS)
         val contactToken = contactTokenDAO.createToken(token, contactId, expiration)
 
         logger.info("Stored contact token $contactToken.")

--- a/src/main/kotlin/sh/zachwal/button/home/WebSocketController.kt
+++ b/src/main/kotlin/sh/zachwal/button/home/WebSocketController.kt
@@ -1,6 +1,5 @@
 package sh.zachwal.button.home
 
-import io.ktor.features.origin
 import io.ktor.routing.Routing
 import io.ktor.sessions.get
 import io.ktor.sessions.sessions
@@ -8,6 +7,7 @@ import io.ktor.websocket.webSocket
 import org.slf4j.LoggerFactory
 import sh.zachwal.button.controller.Controller
 import sh.zachwal.button.db.dao.ContactDAO
+import sh.zachwal.button.ktorutils.remote
 import sh.zachwal.button.presser.PresserFactory
 import sh.zachwal.button.presser.PresserManager
 import sh.zachwal.button.session.principals.ContactSessionPrincipal
@@ -24,20 +24,20 @@ class WebSocketController @Inject constructor(
 
     internal fun Routing.webSocketRoute() {
         webSocket("/socket") {
+            val remote = call.request.remote()
             val contactSession = call.sessions.get<ContactSessionPrincipal>()
             val contact = contactSession?.contactId?.let { contactDAO.findContact(it) }
             if (contact != null) {
-                logger.info("New connection from contact $contact")
+                logger.info("New connection from contact $contact at $remote")
+            } else {
+                logger.info("New connection from $remote")
             }
 
-            val clientHost = call.request.origin.remoteHost
-            val clientPort = call.request.origin.port
-            val remote = "$clientHost:$clientPort"
-            logger.info("New connection from $remote")
             val presser = presserFactory.createPresser(this, remote, contact)
             manager.addPresser(presser)
             presser.watchChannels()
-            logger.info("$clientHost disconnected")
+            logger.info("$remote disconnected")
         }
     }
 }
+

--- a/src/main/kotlin/sh/zachwal/button/home/WebSocketController.kt
+++ b/src/main/kotlin/sh/zachwal/button/home/WebSocketController.kt
@@ -40,4 +40,3 @@ class WebSocketController @Inject constructor(
         }
     }
 }
-

--- a/src/main/kotlin/sh/zachwal/button/ktorutils/Utils.kt
+++ b/src/main/kotlin/sh/zachwal/button/ktorutils/Utils.kt
@@ -1,0 +1,10 @@
+package sh.zachwal.button.ktorutils
+
+import io.ktor.features.origin
+import io.ktor.request.ApplicationRequest
+
+fun ApplicationRequest.remote(): String {
+    val clientHost = origin.remoteHost
+    val clientPort = origin.port
+    return "$clientHost:$clientPort"
+}

--- a/src/main/kotlin/sh/zachwal/button/notify/ContactNotifier.kt
+++ b/src/main/kotlin/sh/zachwal/button/notify/ContactNotifier.kt
@@ -69,6 +69,7 @@ class ContactNotifier @Inject constructor(
                     "triggered by contact=${presser.contact} " +
                     "at remote=${presser.remote()}"
             )
+            // TODO: Create the notification with the triggering contact id & remote address
             notificationDAO.createNotification()
 
             val contacts = contactDAO.selectActiveContacts()

--- a/src/main/kotlin/sh/zachwal/button/notify/ContactNotifier.kt
+++ b/src/main/kotlin/sh/zachwal/button/notify/ContactNotifier.kt
@@ -63,7 +63,12 @@ class ContactNotifier @Inject constructor(
             if (!shouldSendNewNotification) {
                 return@launch
             }
-            logger.info("Last notification was at ${lastNotification?.sentDate}, sending a new one.")
+            logger.info(
+                "Last notification was at ${lastNotification?.sentDate}, " +
+                    "sending a new one " +
+                    "triggered by contact=${presser.contact} " +
+                    "at remote=${presser.remote()}"
+            )
             notificationDAO.createNotification()
 
             val contacts = contactDAO.selectActiveContacts()

--- a/src/main/kotlin/sh/zachwal/button/presser/Presser.kt
+++ b/src/main/kotlin/sh/zachwal/button/presser/Presser.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
 import kotlinx.coroutines.launch
 import org.slf4j.LoggerFactory
 import sh.zachwal.button.db.jdbi.Contact
+import sh.zachwal.button.ktorutils.remote
 
 private val logger = LoggerFactory.getLogger(Presser::class.java)
 
@@ -77,4 +78,6 @@ class Presser constructor(
     suspend fun updatePressingCount(count: Int) {
         countUpdateChannel.send(count)
     }
+
+    fun remote(): String = socketSession.call.request.remote()
 }

--- a/src/main/kotlin/sh/zachwal/button/presser/PresserManager.kt
+++ b/src/main/kotlin/sh/zachwal/button/presser/PresserManager.kt
@@ -15,7 +15,7 @@ class PresserManager : PresserObserver {
     private suspend fun update() {
         val pressingCount = currentlyPressing.count()
         logger.info("Pressing count now $pressingCount")
-        pressers.toTypedArray().forEach { presser ->
+        pressers.forEach { presser ->
             presser.updatePressingCount(pressingCount)
         }
     }

--- a/src/main/kotlin/sh/zachwal/button/presser/PresserManager.kt
+++ b/src/main/kotlin/sh/zachwal/button/presser/PresserManager.kt
@@ -2,6 +2,7 @@ package sh.zachwal.button.presser
 
 import com.google.inject.Singleton
 import org.slf4j.LoggerFactory
+import java.util.concurrent.ConcurrentHashMap
 
 @Singleton
 class PresserManager : PresserObserver {
@@ -9,7 +10,7 @@ class PresserManager : PresserObserver {
     private val logger = LoggerFactory.getLogger(PresserManager::class.java)
     private val pressers = mutableSetOf<Presser>()
 
-    private val currentlyPressing = mutableSetOf<Presser>()
+    private val currentlyPressing: MutableSet<Presser> = ConcurrentHashMap.newKeySet()
 
     private suspend fun update() {
         val pressingCount = currentlyPressing.count()

--- a/src/main/kotlin/sh/zachwal/button/presser/PresserManager.kt
+++ b/src/main/kotlin/sh/zachwal/button/presser/PresserManager.kt
@@ -8,8 +8,8 @@ import java.util.concurrent.ConcurrentHashMap
 class PresserManager : PresserObserver {
 
     private val logger = LoggerFactory.getLogger(PresserManager::class.java)
-    private val pressers = mutableSetOf<Presser>()
 
+    private val pressers: MutableSet<Presser> = ConcurrentHashMap.newKeySet()
     private val currentlyPressing: MutableSet<Presser> = ConcurrentHashMap.newKeySet()
 
     private suspend fun update() {

--- a/src/main/kotlin/sh/zachwal/button/session/SessionService.kt
+++ b/src/main/kotlin/sh/zachwal/button/session/SessionService.kt
@@ -13,12 +13,12 @@ const val CONTACT_SESSION = "CONTACT_SESSION"
 class SessionService {
 
     fun createUserSession(call: ApplicationCall, username: String) {
-        val oneHourAway = Instant.now().plus(1, ChronoUnit.HOURS).toEpochMilli()
-        call.sessions.set(USER_SESSION, UserSessionPrincipal(username, oneHourAway))
+        val oneWeekAway = Instant.now().plus(1, ChronoUnit.WEEKS).toEpochMilli()
+        call.sessions.set(USER_SESSION, UserSessionPrincipal(username, oneWeekAway))
     }
 
     fun createContactSession(call: ApplicationCall, contactId: Int) {
-        val oneWeekAway = Instant.now().plus(7, ChronoUnit.DAYS).toEpochMilli()
-        call.sessions.set(CONTACT_SESSION, ContactSessionPrincipal(contactId, oneWeekAway))
+        val thirtyDaysAway = Instant.now().plus(30, ChronoUnit.DAYS).toEpochMilli()
+        call.sessions.set(CONTACT_SESSION, ContactSessionPrincipal(contactId, thirtyDaysAway))
     }
 }

--- a/src/test/kotlin/sh/zachwal/button/notify/ContactNotifierTest.kt
+++ b/src/test/kotlin/sh/zachwal/button/notify/ContactNotifierTest.kt
@@ -42,7 +42,10 @@ internal class ContactNotifierTest {
 
     private val zachContact = Contact(1, Instant.now(), "Zach", "+18001234567", active = true)
     private val jackieContact = Contact(2, Instant.now(), "Jackie", "+18001225555", active = true)
-    private val presser: Presser = mockk()
+    private val presser: Presser = mockk {
+        every { contact } returns null
+        every { remote() } returns "remote"
+    }
 
     @BeforeEach
     fun setup() {


### PR DESCRIPTION
We typically don't know who first triggered the button text.

To do a few things to fix that:

* Lengthens the session that gets stored for contacts
* (Also lengthens the admin session because it's too short)
* Logs the contact & remote that triggered the notification
* Cleans up some other logs