### PR TITLE
Don't send messages for inactive contacts

### DIFF
--- a/src/test/kotlin/sh/zachwal/button/sms/ControlledContactMessagingServiceTest.kt
+++ b/src/test/kotlin/sh/zachwal/button/sms/ControlledContactMessagingServiceTest.kt
@@ -71,4 +71,19 @@ internal class ControlledContactMessagingServiceTest {
             messagingService.sendMessage(any(), any())
         }
     }
+
+    @Test
+    fun `does not send if the contact is not active`() {
+        val inactiveContact = contact.copy(active = false)
+
+        val messageResult = runBlocking {
+            service.sendMessage(inactiveContact, "body")
+        }
+
+        assertThat(messageResult).isInstanceOf(MessageFailed::class.java)
+
+        coVerify(exactly = 0) {
+            messagingService.sendMessage(any(), any())
+        }
+    }
 }


### PR DESCRIPTION
Check in the `ContactMessagingService` if the contact is active. If not, do not send the message. This allows me to control wrapped by toggling a contact to inactive.