### PR TITLE
Enable ktlint rules with ≤5 violations

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,6 @@ ktlint_standard_function-signature = disabled                  # 179 violations
 ktlint_standard_indent = disabled                              # 3 violations
 ktlint_standard_multiline-expression-wrapping = disabled       # 133 violations
 ktlint_standard_no-empty-first-line-in-class-body = disabled   # 57 violations
-ktlint_standard_no-empty-first-line-in-method-block = disabled # 2 violations
 ktlint_standard_parameter-list-wrapping = disabled             # 18 violations
 ktlint_standard_spacing-between-declarations-with-annotations = disabled # 2 violations
 ktlint_standard_spacing-between-declarations-with-comments = disabled    # 3 violations

--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,6 @@ root = true
 
 [*.{kt,kts}]
 ktlint_standard_annotation = disabled                          # 57 violations
-ktlint_standard_annotation-spacing = disabled                  # 2 violations
 ktlint_standard_argument-list-wrapping = disabled              # 26 violations
 ktlint_standard_blank-line-before-declaration = disabled       # 6 violations
 ktlint_standard_chain-method-continuation = disabled           # 22 violations

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,6 @@ ktlint_standard_chain-method-continuation = disabled           # 22 violations
 ktlint_standard_class-signature = disabled                     # 36 violations
 ktlint_standard_function-expression-body = disabled            # 20 violations
 ktlint_standard_function-signature = disabled                  # 179 violations
-ktlint_standard_indent = disabled                              # 3 violations
 ktlint_standard_multiline-expression-wrapping = disabled       # 133 violations
 ktlint_standard_no-empty-first-line-in-class-body = disabled   # 57 violations
 ktlint_standard_parameter-list-wrapping = disabled             # 18 violations

--- a/.editorconfig
+++ b/.editorconfig
@@ -14,7 +14,6 @@ ktlint_standard_max-line-length = disabled                     # 3 violations
 ktlint_standard_multiline-expression-wrapping = disabled       # 133 violations
 ktlint_standard_no-empty-first-line-in-class-body = disabled   # 57 violations
 ktlint_standard_no-empty-first-line-in-method-block = disabled # 2 violations
-ktlint_standard_no-semi = disabled                             # 1 violation
 ktlint_standard_parameter-list-wrapping = disabled             # 18 violations
 ktlint_standard_spacing-between-declarations-with-annotations = disabled # 2 violations
 ktlint_standard_spacing-between-declarations-with-comments = disabled    # 3 violations

--- a/.editorconfig
+++ b/.editorconfig
@@ -13,7 +13,6 @@ ktlint_standard_indent = disabled                              # 3 violations
 ktlint_standard_multiline-expression-wrapping = disabled       # 133 violations
 ktlint_standard_no-empty-first-line-in-class-body = disabled   # 57 violations
 ktlint_standard_parameter-list-wrapping = disabled             # 18 violations
-ktlint_standard_spacing-between-declarations-with-annotations = disabled # 2 violations
 ktlint_standard_spacing-between-declarations-with-comments = disabled    # 3 violations
 ktlint_standard_string-template-indent = disabled              # 14 violations
 ktlint_standard_trailing-comma-on-call-site = disabled         # 134 violations

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,6 @@ ktlint_standard_class-signature = disabled                     # 36 violations
 ktlint_standard_function-expression-body = disabled            # 20 violations
 ktlint_standard_function-signature = disabled                  # 179 violations
 ktlint_standard_indent = disabled                              # 3 violations
-ktlint_standard_max-line-length = disabled                     # 3 violations
 ktlint_standard_multiline-expression-wrapping = disabled       # 133 violations
 ktlint_standard_no-empty-first-line-in-class-body = disabled   # 57 violations
 ktlint_standard_no-empty-first-line-in-method-block = disabled # 2 violations

--- a/.editorconfig
+++ b/.editorconfig
@@ -13,7 +13,6 @@ ktlint_standard_indent = disabled                              # 3 violations
 ktlint_standard_multiline-expression-wrapping = disabled       # 133 violations
 ktlint_standard_no-empty-first-line-in-class-body = disabled   # 57 violations
 ktlint_standard_parameter-list-wrapping = disabled             # 18 violations
-ktlint_standard_spacing-between-declarations-with-comments = disabled    # 3 violations
 ktlint_standard_string-template-indent = disabled              # 14 violations
 ktlint_standard_trailing-comma-on-call-site = disabled         # 134 violations
 ktlint_standard_trailing-comma-on-declaration-site = disabled  # 42 violations

--- a/src/main/kotlin/sh/zachwal/button/App.kt
+++ b/src/main/kotlin/sh/zachwal/button/App.kt
@@ -56,7 +56,6 @@ fun main(args: Array<String>): Unit = io.ktor.server.netty.EngineMain.main(args)
 @Suppress("unused") // Referenced in application.conf
 @kotlin.jvm.JvmOverloads
 fun Application.module(testing: Boolean = false) {
-
     val injector = Guice.createInjector(
         ApplicationModule(),
         ConfigModule(environment.config),

--- a/src/main/kotlin/sh/zachwal/button/db/dao/PressDAO.kt
+++ b/src/main/kotlin/sh/zachwal/button/db/dao/PressDAO.kt
@@ -54,6 +54,7 @@ interface PressDAO {
         """
     )
     fun allPressesForContact(contactId: Int): Stream<Press>
+
     @SqlQuery(
         """
         select min(time) from public.press where contact_id = :contactId

--- a/src/main/kotlin/sh/zachwal/button/features/ConfigureRoleAuthorization.kt
+++ b/src/main/kotlin/sh/zachwal/button/features/ConfigureRoleAuthorization.kt
@@ -6,7 +6,12 @@ import sh.zachwal.button.roles.RoleAuthorization.RoleBasedAuthorizer
 import sh.zachwal.button.roles.RoleService
 import sh.zachwal.button.users.UserService
 
-fun configureRoleAuthorization(roleBasedAuthorizer: RoleBasedAuthorizer, application: Application, userService: UserService, roleService: RoleService) {
+fun configureRoleAuthorization(
+    roleBasedAuthorizer: RoleBasedAuthorizer,
+    application: Application,
+    userService: UserService,
+    roleService: RoleService
+) {
     roleBasedAuthorizer.validate { roles, session ->
         application.log.info("Checking $roles for session ${session.user}")
         val user = userService.getUser(session.user)

--- a/src/main/kotlin/sh/zachwal/button/features/ConfigureStatusPages.kt
+++ b/src/main/kotlin/sh/zachwal/button/features/ConfigureStatusPages.kt
@@ -58,7 +58,7 @@ fun StatusPagesConfig.configureStatusPages() {
                     +(
                         "You are not logged in, or do not have the correct permissions, to access " +
                             call.request.uri
-                        )
+                    )
                 }
                 p {
                     +"${cause.message}"

--- a/src/main/kotlin/sh/zachwal/button/features/ConfigureStatusPages.kt
+++ b/src/main/kotlin/sh/zachwal/button/features/ConfigureStatusPages.kt
@@ -20,7 +20,6 @@ import sh.zachwal.button.sharedhtml.headSetup
 private val logger = LoggerFactory.getLogger("StatusPage")
 
 fun StatusPagesConfig.configureStatusPages() {
-
     exception<Throwable> { call, cause ->
         logger.error("Unhandled error", cause)
         Sentry.captureException(cause)

--- a/src/main/kotlin/sh/zachwal/button/home/WebSocketController.kt
+++ b/src/main/kotlin/sh/zachwal/button/home/WebSocketController.kt
@@ -13,12 +13,12 @@ import sh.zachwal.button.presser.PresserManager
 import sh.zachwal.button.session.principals.ContactSessionPrincipal
 import javax.inject.Inject
 
-@Controller
 /**
  * Ktor controller that handles the /socket WebSocket endpoint for button pressers.
  *
  * Authenticates users, creates Presser instances for each connection, and integrates them into the system.
  */
+@Controller
 class WebSocketController @Inject constructor(
     private val manager: PresserManager,
     private val presserFactory: PresserFactory,

--- a/src/main/kotlin/sh/zachwal/button/phone/PhoneController.kt
+++ b/src/main/kotlin/sh/zachwal/button/phone/PhoneController.kt
@@ -66,7 +66,7 @@ class PhoneController @Inject constructor(private val phoneBookService: PhoneBoo
                                                             "someone " +
                                                             "presses the " +
                                                             "button so you can join in!"
-                                                        )
+                                                    )
                                                 }
                                             }
                                             div(classes = "form-group") {
@@ -159,7 +159,7 @@ class PhoneController @Inject constructor(private val phoneBookService: PhoneBoo
                                         "You'll receive texts from now on the first time the button" +
                                             " " +
                                             "is pressed in a given day."
-                                        )
+                                    )
                                 }
                                 a(href = "/", classes = "button") {
                                     span {

--- a/src/main/kotlin/sh/zachwal/button/presser/Presser.kt
+++ b/src/main/kotlin/sh/zachwal/button/presser/Presser.kt
@@ -52,10 +52,13 @@ class Presser constructor(
 
     // updates to the current count of pressers
     private val countUpdateChannel = Channel<Int>(10, onBufferOverflow = BufferOverflow.DROP_LATEST)
+
     // person pressing notifications
     private val personPressingChannel = Channel<String>(10, onBufferOverflow = BufferOverflow.DROP_LATEST)
+
     // person released notifications
     private val personReleasedChannel = Channel<String>(10, onBufferOverflow = BufferOverflow.DROP_LATEST)
+
     // snapshot messages (only need the latest)
     private val snapshotChannel = Channel<Snapshot>(1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
 

--- a/src/main/kotlin/sh/zachwal/button/presser/PresserFactory.kt
+++ b/src/main/kotlin/sh/zachwal/button/presser/PresserFactory.kt
@@ -11,12 +11,12 @@ import sh.zachwal.button.notify.ContactNotifier
 import sh.zachwal.button.presshistory.PressHistoryObserver
 import sh.zachwal.button.presshistory.PressLogger
 
-@Singleton
 /**
  * Factory for creating Presser instances, wiring them with the appropriate observers and dependencies.
  *
  * Ensures each Presser is connected to the global data flow (via PresserManager, PressHistoryObserver, etc).
  */
+@Singleton
 class PresserFactory @Inject constructor(
     private val presserManager: PresserManager,
     private val presserHistoryObserver: PressHistoryObserver,

--- a/src/main/kotlin/sh/zachwal/button/presser/protocol/client/PressState.kt
+++ b/src/main/kotlin/sh/zachwal/button/presser/protocol/client/PressState.kt
@@ -2,5 +2,5 @@ package sh.zachwal.button.presser.protocol.client
 
 enum class PressState {
     PRESSING,
-    RELEASED;
+    RELEASED
 }

--- a/src/test/kotlin/sh/zachwal/button/db/dao/ContactPressCountDAOTest.kt
+++ b/src/test/kotlin/sh/zachwal/button/db/dao/ContactPressCountDAOTest.kt
@@ -19,8 +19,16 @@ class ContactPressCountDAOTest(private val jdbi: Jdbi) {
         dao = jdbi.onDemand(ContactPressCountDAO::class.java)
         // Insert contacts 1 and 2 for FK constraint
         jdbi.useHandle<Exception> { h ->
-            h.execute("insert into contact (id, created_date, name, phone_number, active) values (1, now(), 'Contact 1', '+15550001', true)")
-            h.execute("insert into contact (id, created_date, name, phone_number, active) values (2, now(), 'Contact 2', '+15550002', true)")
+            h.execute(
+                "insert into contact " +
+                    "(id, created_date, name, phone_number, active) " +
+                    "values (1, now(), 'Contact 1', '+15550001', true)"
+            )
+            h.execute(
+                "insert into contact " +
+                    "(id, created_date, name, phone_number, active) " +
+                    "values (2, now(), 'Contact 2', '+15550002', true)"
+            )
         }
     }
 

--- a/src/test/kotlin/sh/zachwal/button/presshistory/PressHistoryObserverTest.kt
+++ b/src/test/kotlin/sh/zachwal/button/presshistory/PressHistoryObserverTest.kt
@@ -61,6 +61,7 @@ internal class PressHistoryObserverTest {
             pressDAO.createPress(remoteHost, null)
         }
     }
+
     @Test
     fun `uses the contact id of the presser on the press`() {
         val presser = mockk<Presser>()


### PR DESCRIPTION
## Summary

- Enables 7 ktlint rules that had 5 or fewer violations each: `annotation-spacing`, `indent`, `max-line-length`, `no-empty-first-line-in-method-block`, `no-semi`, `spacing-between-declarations-with-annotations`, `spacing-between-declarations-with-comments`
- Auto-formats all violations across source and test files to comply with the newly enabled rules
- Removes the corresponding `disabled` lines from `.editorconfig`

## Changes

| Rule | Violations fixed |
|---|---|
| `no-semi` | 1 |
| `annotation-spacing` | 2 |
| `no-empty-first-line-in-method-block` | 2 |
| `spacing-between-declarations-with-annotations` | 2 |
| `spacing-between-declarations-with-comments` | 3 |
| `indent` | 3 |
| `max-line-length` | 3 |

## Test plan
- [ ] `./gradlew ktlintCheck` passes with no violations
- [ ] `./gradlew build` passes (all tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)