### PR TITLE
Fix peak_concurrent tracking and add DailyStatsService tests

### DIFF
--- a/src/main/kotlin/sh/zachwal/button/presshistory/DailyStatsService.kt
+++ b/src/main/kotlin/sh/zachwal/button/presshistory/DailyStatsService.kt
@@ -14,6 +14,7 @@ import sh.zachwal.button.db.dao.DailyPressersDAO
 import sh.zachwal.button.db.dao.DailyStatsDAO
 import sh.zachwal.button.presser.Presser
 import sh.zachwal.button.presser.PresserObserver
+import java.time.Clock
 import java.time.LocalDate
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
@@ -36,12 +37,14 @@ class DailyStatsService @Inject constructor(
 
     private val logger = LoggerFactory.getLogger(DailyStatsService::class.java)
 
+    internal var clock: Clock = Clock.systemDefaultZone()
+
     private val uniquePresserIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
     private val peakConcurrent = AtomicInteger(0)
     private val totalPressCount = AtomicInteger(0)
 
     @Volatile
-    private var trackingDate: LocalDate = LocalDate.now()
+    private var trackingDate: LocalDate = LocalDate.now(clock)
 
     private val dbOpChannel = Channel<DbOp>(
         capacity = 1000,
@@ -73,7 +76,7 @@ class DailyStatsService @Inject constructor(
     }
 
     fun initialize() {
-        val today = LocalDate.now()
+        val today = LocalDate.now(clock)
         dailyStatsDAO.ensureRow(today)
         val row = dailyStatsDAO.findByDate(today)
         uniquePresserIds.clear()
@@ -88,7 +91,7 @@ class DailyStatsService @Inject constructor(
     }
 
     override suspend fun pressed(presser: Presser) {
-        val today = LocalDate.now()
+        val today = LocalDate.now(clock)
         if (today != trackingDate) {
             initialize()
         }

--- a/src/main/kotlin/sh/zachwal/button/presshistory/DailyStatsService.kt
+++ b/src/main/kotlin/sh/zachwal/button/presshistory/DailyStatsService.kt
@@ -40,6 +40,7 @@ class DailyStatsService @Inject constructor(
     internal var clock: Clock = Clock.systemDefaultZone()
 
     private val uniquePresserIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
+    private val currentlyPressing: MutableSet<Presser> = ConcurrentHashMap.newKeySet()
     private val peakConcurrent = AtomicInteger(0)
     private val totalPressCount = AtomicInteger(0)
 
@@ -95,6 +96,8 @@ class DailyStatsService @Inject constructor(
         if (today != trackingDate) {
             initialize()
         }
+        currentlyPressing.add(presser)
+        updatePeak(currentlyPressing.size)
         val presserId = presser.contact?.id?.toString() ?: presser.remoteHost
         totalPressCount.incrementAndGet()
         val isNewPresser = uniquePresserIds.add(presserId)
@@ -104,9 +107,13 @@ class DailyStatsService @Inject constructor(
         dbOpChannel.trySend(NewPress(today))
     }
 
-    override suspend fun released(presser: Presser) {}
+    override suspend fun released(presser: Presser) {
+        currentlyPressing.remove(presser)
+    }
 
-    override suspend fun disconnected(presser: Presser) {}
+    override suspend fun disconnected(presser: Presser) {
+        currentlyPressing.remove(presser)
+    }
 
     fun updatePeak(concurrentCount: Int) {
         val prevPeak = peakConcurrent.getAndUpdate { max(it, concurrentCount) }

--- a/src/test/kotlin/sh/zachwal/button/presshistory/DailyStatsServiceTest.kt
+++ b/src/test/kotlin/sh/zachwal/button/presshistory/DailyStatsServiceTest.kt
@@ -114,6 +114,54 @@ class DailyStatsServiceTest(private val jdbi: Jdbi) {
     }
 
     @Test
+    fun `peak concurrent rises as more pressers press simultaneously`() = runBlocking {
+        val presserA = mockPresser("1.1.1.1")
+        val presserB = mockPresser("2.2.2.2")
+        val presserC = mockPresser("3.3.3.3")
+
+        service.pressed(presserA)
+        assertThat(service.currentStats().peakConcurrent).isEqualTo(1)
+
+        service.pressed(presserB)
+        assertThat(service.currentStats().peakConcurrent).isEqualTo(2)
+
+        service.released(presserA)
+        assertThat(service.currentStats().peakConcurrent).isEqualTo(2) // peak doesn't drop on release
+
+        service.pressed(presserC) // back to 2 concurrent, not a new peak
+        assertThat(service.currentStats().peakConcurrent).isEqualTo(2)
+    }
+
+    @Test
+    fun `peak concurrent is persisted to DB`() = runBlocking {
+        val presserA = mockPresser("1.1.1.1")
+        val presserB = mockPresser("2.2.2.2")
+
+        service.pressed(presserA)
+        service.pressed(presserB)
+        service.released(presserA)
+
+        service.close()
+
+        val row = dailyStatsDAO.findByDate(today)
+        assertThat(row!!.peakConcurrent).isEqualTo(2)
+    }
+
+    @Test
+    fun `disconnected presser is no longer counted toward concurrent`() = runBlocking {
+        val presserA = mockPresser("1.1.1.1")
+        val presserB = mockPresser("2.2.2.2")
+        val presserC = mockPresser("3.3.3.3")
+
+        service.pressed(presserA)
+        service.pressed(presserB)
+        service.disconnected(presserA) // A disconnects without releasing
+
+        service.pressed(presserC) // B + C = 2, not a new peak
+        assertThat(service.currentStats().peakConcurrent).isEqualTo(2)
+    }
+
+    @Test
     fun `concurrent pressed calls are thread-safe`() {
         val executor = Executors.newFixedThreadPool(4)
         val futures = (1..100).map { i ->
@@ -134,8 +182,12 @@ class DailyStatsServiceTest(private val jdbi: Jdbi) {
 
     @Test
     fun `day rollover resets in-memory stats`() = runBlocking {
-        service.pressed(mockPresser("1.2.3.4"))
-        service.pressed(mockPresser("5.6.7.8"))
+        val presserA = mockPresser("1.2.3.4")
+        val presserB = mockPresser("5.6.7.8")
+        service.pressed(presserA)
+        service.pressed(presserB)
+        service.released(presserA)
+        service.released(presserB)
         assertThat(service.currentStats().totalPresses).isEqualTo(2)
         assertThat(service.currentStats().uniquePressers).isEqualTo(2)
 
@@ -145,7 +197,19 @@ class DailyStatsServiceTest(private val jdbi: Jdbi) {
         val stats = service.currentStats()
         assertThat(stats.totalPresses).isEqualTo(1)
         assertThat(stats.uniquePressers).isEqualTo(1)
-        assertThat(stats.peakConcurrent).isEqualTo(0)
+        assertThat(stats.peakConcurrent).isEqualTo(1)
+    }
+
+    @Test
+    fun `presser still pressing at midnight is counted toward new day peak`() = runBlocking {
+        val presserA = mockPresser("1.2.3.4")
+        service.pressed(presserA) // pressing at end of day 1, never released
+
+        service.clock = clockFor(today.plusDays(1))
+        service.pressed(mockPresser("5.6.7.8")) // triggers rollover; A is still pressing
+
+        // A + new presser = 2 concurrent
+        assertThat(service.currentStats().peakConcurrent).isEqualTo(2)
     }
 
     @Test

--- a/src/test/kotlin/sh/zachwal/button/presshistory/DailyStatsServiceTest.kt
+++ b/src/test/kotlin/sh/zachwal/button/presshistory/DailyStatsServiceTest.kt
@@ -15,8 +15,10 @@ import sh.zachwal.button.db.dao.DailyStatsDAO
 import sh.zachwal.button.db.extension.DatabaseExtension
 import sh.zachwal.button.db.jdbi.Contact
 import sh.zachwal.button.presser.Presser
+import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
+import java.time.ZoneId
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
@@ -42,6 +44,11 @@ class DailyStatsServiceTest(private val jdbi: Jdbi) {
         // Drain pending DB ops before DatabaseExtension truncates tables
         service.close()
     }
+
+    private val zone: ZoneId = ZoneId.systemDefault()
+
+    private fun clockFor(date: LocalDate): Clock =
+        Clock.fixed(date.atStartOfDay(zone).toInstant(), zone)
 
     private fun mockPresser(remoteHost: String = "127.0.0.1", contact: Contact? = null): Presser {
         return mockk<Presser>().also {
@@ -123,6 +130,51 @@ class DailyStatsServiceTest(private val jdbi: Jdbi) {
         val stats = service.currentStats()
         assertThat(stats.totalPresses).isEqualTo(100)
         assertThat(stats.uniquePressers).isEqualTo(100)
+    }
+
+    @Test
+    fun `day rollover resets in-memory stats`() = runBlocking {
+        service.pressed(mockPresser("1.2.3.4"))
+        service.pressed(mockPresser("5.6.7.8"))
+        assertThat(service.currentStats().totalPresses).isEqualTo(2)
+        assertThat(service.currentStats().uniquePressers).isEqualTo(2)
+
+        service.clock = clockFor(today.plusDays(1))
+        service.pressed(mockPresser("9.10.11.12"))
+
+        val stats = service.currentStats()
+        assertThat(stats.totalPresses).isEqualTo(1)
+        assertThat(stats.uniquePressers).isEqualTo(1)
+        assertThat(stats.peakConcurrent).isEqualTo(0)
+    }
+
+    @Test
+    fun `day rollover loads existing DB state for the new day`() = runBlocking {
+        val tomorrow = today.plusDays(1)
+        dailyStatsDAO.ensureRow(tomorrow)
+        dailyStatsDAO.incrementTotalPresses(tomorrow)
+        dailyStatsDAO.incrementTotalPresses(tomorrow)
+        dailyStatsDAO.updatePeakIfHigher(tomorrow, 7)
+        dailyPressersDAO.insertIfAbsent(tomorrow, "existing-presser")
+
+        service.clock = clockFor(tomorrow)
+        service.pressed(mockPresser("new-host"))
+
+        val stats = service.currentStats()
+        assertThat(stats.totalPresses).isEqualTo(3) // 2 pre-existing + 1 new press
+        assertThat(stats.peakConcurrent).isEqualTo(7) // loaded from DB
+        assertThat(stats.uniquePressers).isEqualTo(2) // "existing-presser" + "new-host"
+    }
+
+    @Test
+    fun `day rollover does not trigger within the same day`() = runBlocking {
+        service.pressed(mockPresser("1.2.3.4"))
+        service.pressed(mockPresser("5.6.7.8"))
+        service.pressed(mockPresser("1.2.3.4")) // same presser again
+
+        val stats = service.currentStats()
+        assertThat(stats.totalPresses).isEqualTo(3)
+        assertThat(stats.uniquePressers).isEqualTo(2)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- **Bug fix**: `peak_concurrent` was always 0 in production because `updatePeak()` was never called from the press flow. `PresserManager` tracked concurrent pressers but had no reference to `DailyStatsService`. Fixed by having `DailyStatsService` maintain its own `currentlyPressing` set — `pressed()` now adds the presser and calls `updatePeak`, while `released()` and `disconnected()` remove them.
- **Day rollover tests**: Added an injectable `Clock` to `DailyStatsService` (internal var, defaults to system clock) so tests can simulate day boundaries. Added tests for stat reset on rollover, DB state reload for the new day, and a presser holding through midnight carrying into the new day's peak.
- **Peak persistence tests**: Added tests verifying peak rises with simultaneous pressers, is written to DB, and that released/disconnected pressers are removed from the concurrent count.

## Test plan

- [ ] All existing tests still pass
- [ ] `peak concurrent rises as more pressers press simultaneously` — verifies in-memory tracking
- [ ] `peak concurrent is persisted to DB` — verifies the DB write path end-to-end
- [ ] `disconnected presser is no longer counted toward concurrent` — verifies disconnects are handled
- [ ] `presser still pressing at midnight is counted toward new day peak` — verifies midnight edge case
- [ ] `day rollover resets in-memory stats` — verifies totals/unique reset on new day
- [ ] `day rollover loads existing DB state for the new day` — verifies reload from DB on rollover

🤖 Generated with [Claude Code](https://claude.com/claude-code)