### PR TITLE
Daily stats PR 3: DailyStats protocol message and PresserManager integration

### DIFF
--- a/docs/daily-stats/PLAN.md
+++ b/docs/daily-stats/PLAN.md
@@ -1,0 +1,51 @@
+# Daily Stats Feature Plan
+
+## Problem
+Users who join late see only themselves pressing the button. Showing daily stats creates
+engagement even for late arrivals.
+
+## Goal
+Display stats under the "BUTTON PRESSERS: N" heading:
+> 4 pressers today · peak 2 · 17 presses
+
+## Storage
+Two new tables:
+- `daily_stats(date DATE PK, peak_concurrent INT, total_press_count INT)` — one row per day
+- `daily_pressers(date DATE, presser_id TEXT, PRIMARY KEY (date, presser_id))` — one row per unique presser per day
+
+Presser identity: `contact_id.toString()` if authenticated, else `remoteHost`.
+
+## DailyStatsService
+Implements `PresserObserver` and maintains thread-safe in-memory state for the current day:
+- `uniquePresserIds: ConcurrentHashMap.newKeySet<String>()` — loaded from `daily_pressers` on startup
+- `peakConcurrent: AtomicInteger`, `totalPressCount: AtomicInteger` — loaded from `daily_stats` on startup
+- `trackingDate: LocalDate` — if rolled past midnight, re-initialize from DB before proceeding
+
+Uses `AtomicInteger` and `ConcurrentHashMap`-backed set for thread safety, since observer
+callbacks arrive from the multi-threaded `presserDispatcher`.
+
+Wired into `MultiPresserObserver` (before `PresserManager`) so that stats are updated before
+`PresserManager` reads them. `PresserManager` is also injected with `DailyStatsService` directly
+so it can call `updatePeak(concurrentCount)` (after adding to `currentlyPressing`) and
+`currentStats()` (to build and broadcast the `DailyStats` message).
+
+DB writes are queued via a `Channel<DbOp>` consumed by a single background coroutine:
+- New presser: `INSERT INTO daily_pressers ... ON CONFLICT DO NOTHING`
+- Every press: `UPDATE daily_stats SET total_press_count = total_press_count + 1`
+- New peak: `UPDATE daily_stats SET peak_concurrent = GREATEST(peak_concurrent, :n)`
+
+## Protocol
+New `DailyStats` ServerMessage:
+```json
+{ "type": "DailyStats", "uniquePressers": 4, "peakConcurrent": 2, "totalPresses": 17 }
+```
+Sent on every press, on new connection, and bundled into `Snapshot`.
+
+## Implementation phases
+
+| PR | Scope |
+|----|-------|
+| PR 1 | DB migrations only: `daily_stats` + `daily_pressers` tables |
+| PR 2 | `DailyStatsService`, DAOs, tests |
+| PR 3 | Protocol message, `PresserManager` integration, `Snapshot` extension |
+| PR 4 | Frontend display |

--- a/docs/daily-stats/PR_1.md
+++ b/docs/daily-stats/PR_1.md
@@ -1,0 +1,77 @@
+# PR 1: DB Migrations
+
+## Goal
+Create the two new tables, with their DAOs and tests.
+
+## Files to create
+
+### `db/13_create_daily_stats.json`
+```sql
+CREATE TABLE daily_stats (
+    date              DATE NOT NULL,
+    peak_concurrent   INT  NOT NULL DEFAULT 0,
+    total_press_count INT  NOT NULL DEFAULT 0,
+    CONSTRAINT pk_daily_stats PRIMARY KEY (date)
+);
+```
+
+### `db/14_create_daily_pressers.json`
+```sql
+CREATE TABLE daily_pressers (
+    date       DATE NOT NULL,
+    presser_id TEXT NOT NULL,
+    CONSTRAINT pk_daily_pressers PRIMARY KEY (date, presser_id)
+);
+```
+
+
+### Model: `src/main/kotlin/sh/zachwal/button/db/jdbi/DailyStatsRow.kt`
+```kotlin
+data class DailyStatsRow(
+    val date: LocalDate,
+    val peakConcurrent: Int,
+    val totalPressCount: Int,
+)
+```
+
+### DAO: `src/main/kotlin/sh/zachwal/button/db/dao/DailyStatsDAO.kt`
+```kotlin
+interface DailyStatsDAO {
+    @SqlQuery("SELECT * FROM daily_stats WHERE date = :date")
+    fun findByDate(@Bind("date") date: LocalDate): DailyStatsRow?
+
+    @SqlUpdate("INSERT INTO daily_stats (date) VALUES (:date) ON CONFLICT DO NOTHING")
+    fun ensureRow(@Bind("date") date: LocalDate)
+
+    @SqlUpdate("UPDATE daily_stats SET total_press_count = total_press_count + 1 WHERE date = :date")
+    fun incrementTotalPresses(@Bind("date") date: LocalDate)
+
+    @SqlUpdate("UPDATE daily_stats SET peak_concurrent = GREATEST(peak_concurrent, :peak) WHERE date = :date")
+    fun updatePeakIfHigher(@Bind("date") date: LocalDate, @Bind("peak") peak: Int)
+}
+```
+
+### DAO: `src/main/kotlin/sh/zachwal/button/db/dao/DailyPressersDAO.kt`
+```kotlin
+interface DailyPressersDAO {
+    @SqlQuery("SELECT presser_id FROM daily_pressers WHERE date = :date")
+    fun findByDate(@Bind("date") date: LocalDate): List<String>
+
+    // Returns true if the row was inserted (presser is new for this date)
+    @SqlQuery("""
+        INSERT INTO daily_pressers (date, presser_id) VALUES (:date, :presserId)
+        ON CONFLICT DO NOTHING
+        RETURNING presser_id
+    """)
+    fun insertIfAbsent(@Bind("date") date: LocalDate, @Bind("presserId") presserId: String): String?
+}
+```
+
+## Files to modify
+- `db/changelog.json` — add both new changeset entries
+
+## Verification
+Run migrations against test DB; confirm both tables exist with correct constraints.
+
+## Tests
+Write integration tests of the DAOs using existing TestContainers PostgreSQL patterns.

--- a/docs/daily-stats/PR_2.md
+++ b/docs/daily-stats/PR_2.md
@@ -1,0 +1,64 @@
+# PR 2: DailyStatsService
+
+## Goal
+Implement `DailyStatsService` with its tests. No protocol or frontend changes.
+
+## Files to create
+
+### Service: `src/main/kotlin/sh/zachwal/button/presshistory/DailyStatsService.kt`
+Sealed class for DB operations sent over the channel:
+```kotlin
+sealed class DbOp
+data class NewPress(val date: LocalDate, val newPeak: Int?) : DbOp()  // newPeak non-null if peak was broken
+data class NewPresser(val date: LocalDate, val presserId: String) : DbOp()
+```
+
+Implements `PresserObserver`. Thread-safe via `AtomicInteger` and `ConcurrentHashMap`-backed set
+(observer callbacks arrive from the multi-threaded `presserDispatcher`).
+
+Key behaviors:
+- `initialize()`: loads today's row from `daily_stats`, loads `daily_pressers` for today into `uniquePresserIds`
+- Observer callback `pressed(presser)`:
+  1. Check midnight rollover (`LocalDate.now()` vs `trackingDate`); call `initialize()` if rolled
+  2. Derive `presserId = presser.contact?.id?.toString() ?: presser.remoteHost`
+  3. `totalPressCount.incrementAndGet()`
+  4. `uniquePresserIds.add(presserId)` — if returns true, enqueue `NewPresser` DB op
+  5. Enqueue `NewPress` DB op
+- Observer callbacks `released(presser)` and `disconnected(presser)`: no-op
+- `updatePeak(concurrentCount: Int)`: called by `PresserManager` after adding to `currentlyPressing`; uses `peakConcurrent.updateAndGet { max(it, concurrentCount) }`; enqueues DB op if peak changed
+- `currentStats(): DailyStatsSnapshot` — returns snapshot of current in-memory values
+- Background coroutine consumes `Channel<DbOp>` and executes DB writes
+
+In-memory state (thread-safe):
+```kotlin
+private val uniquePresserIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
+private val peakConcurrent = AtomicInteger(0)
+private val totalPressCount = AtomicInteger(0)
+```
+
+`DailyStatsSnapshot` is an in-memory value type (not the JDBI model) returned to callers:
+```kotlin
+data class DailyStatsSnapshot(val uniquePressers: Int, val peakConcurrent: Int, val totalPresses: Int)
+```
+
+Constructor injection: `DailyStatsDAO`, `DailyPressersDAO`.
+
+## Files to modify
+- `src/main/kotlin/sh/zachwal/button/db/JdbiModule.kt` — register `DailyStatsDAO`, `DailyPressersDAO`
+- `src/main/kotlin/sh/zachwal/button/guice/ApplicationModule.kt` — bind `DailyStatsService` as eager singleton, call `initialize()`
+- `src/main/kotlin/sh/zachwal/button/presser/PresserFactory.kt` — add `DailyStatsService` to `MultiPresserObserver` list, **before** `PresserManager` so stats are updated before the manager reads them
+
+## Tests
+`src/test/kotlin/sh/zachwal/button/presshistory/DailyStatsServiceTest.kt`
+- Uses TestContainers PostgreSQL (follow pattern of existing integration tests)
+- First press increments totalPresses, uniquePressers = 1
+- Same presser again increments totalPresses only
+- New presser increments uniquePressers (via daily_pressers insert)
+- `updatePeak` with higher count updates peak; lower does not
+- Concurrent calls to `pressed()` are safe (thread-safety test)
+- `initialize()` reloads correctly after simulated restart
+
+## Verification
+```bash
+./gradlew test --tests DailyStatsServiceTest
+```

--- a/docs/daily-stats/PR_3.md
+++ b/docs/daily-stats/PR_3.md
@@ -1,0 +1,58 @@
+# PR 3: Protocol + PresserManager Integration
+
+## Goal
+Add the `DailyStats` ServerMessage and wire `DailyStatsService` into `PresserManager` for broadcasting.
+
+## Files to create
+
+### `src/main/kotlin/sh/zachwal/button/presser/protocol/server/DailyStats.kt`
+```kotlin
+data class DailyStats(
+    val uniquePressers: Int,
+    val peakConcurrent: Int,
+    val totalPresses: Int,
+) : ServerMessage
+```
+
+## Files to modify
+
+### `src/main/kotlin/sh/zachwal/button/presser/protocol/server/ServerMessage.kt`
+Add `DailyStats` to the `@JsonSubTypes` annotation:
+```kotlin
+@JsonSubTypes(
+    JsonSubTypes.Type(CurrentCount::class),
+    JsonSubTypes.Type(PersonPressing::class),
+    JsonSubTypes.Type(PersonReleased::class),
+    JsonSubTypes.Type(Snapshot::class),
+    JsonSubTypes.Type(DailyStats::class),  // new
+)
+```
+
+### `src/main/kotlin/sh/zachwal/button/presser/protocol/server/Snapshot.kt`
+Add field:
+```kotlin
+data class Snapshot(
+    val count: Int,
+    val names: List<String>,
+    val dailyStats: DailyStats,  // new
+) : ServerMessage
+```
+
+### `src/main/kotlin/sh/zachwal/button/presser/Presser.kt`
+Add channel and send helper for `DailyStats` (mirroring existing `countUpdateChannel` pattern).
+
+### `src/main/kotlin/sh/zachwal/button/presser/PresserManager.kt`
+- Inject `DailyStatsService`
+- `addPresser()`: send `dailyStatsService.currentStats()` as `DailyStats` message to new presser
+- `pressed()` (after existing `currentlyPressing.add(presser)`):
+  1. Call `dailyStatsService.updatePeak(currentlyPressing.size)`
+  2. Read `dailyStatsService.currentStats()` and broadcast as `DailyStats` message to all pressers
+  (Note: `DailyStatsService.pressed()` has already run via `MultiPresserObserver` before
+  `PresserManager.pressed()`, so totalPresses and uniquePressers are already updated.)
+- `buildSnapshot()`: include `dailyStatsService.currentStats()` in `Snapshot`
+
+## Verification
+```bash
+./gradlew build
+```
+Manual: open two browser tabs, press in one — verify WS frames contain `DailyStats` messages in both.

--- a/docs/daily-stats/PR_4.md
+++ b/docs/daily-stats/PR_4.md
@@ -1,0 +1,45 @@
+# PR 4: Frontend Display
+
+## Goal
+Display daily stats below the "BUTTON PRESSERS: N" heading.
+
+## Files to modify
+
+### `src/main/kotlin/sh/zachwal/button/home/HomeController.kt`
+Add `id="dailyStats"` and `id="dailyStatsWhite"` elements under `#buttonPressCount`,
+matching the existing two-element pattern for the fireworks background. Start empty —
+stats arrive on the first WebSocket message.
+
+### `frontend/src/main/js/net/socket.js`
+```js
+case 'DailyStats':
+  this._handlers.onDailyStats?.(msg)
+  break
+```
+
+### `frontend/src/main/js/bootstrap/main.js`
+```js
+function setDailyStats({ uniquePressers, peakConcurrent, totalPresses }) {
+  const text = `${uniquePressers} pressers today · peak ${peakConcurrent} · ${totalPresses} presses`
+  document.getElementById('dailyStats').innerText = text
+  document.getElementById('dailyStatsWhite').innerText = text
+}
+
+// In socket handlers:
+onDailyStats: (msg) => setDailyStats(msg),
+// In onSnapshot handler, add:
+setDailyStats(msg.dailyStats)
+```
+
+### CSS
+Style `#dailyStats` and `#dailyStatsWhite` with smaller text under the main counter.
+Starting point: `font-size: 0.6em; opacity: 0.8; margin-top: 0.25em;`
+
+## Tests
+Add frontend tests for `setDailyStats` rendering and `DailyStats` socket message dispatch.
+
+## Verification
+```bash
+npm --prefix frontend test
+./gradlew build
+```

--- a/src/main/kotlin/sh/zachwal/button/presser/Presser.kt
+++ b/src/main/kotlin/sh/zachwal/button/presser/Presser.kt
@@ -24,6 +24,7 @@ import sh.zachwal.button.presser.protocol.client.ClientMessage
 import sh.zachwal.button.presser.protocol.client.PressState
 import sh.zachwal.button.presser.protocol.client.PressStateChanged
 import sh.zachwal.button.presser.protocol.server.CurrentCount
+import sh.zachwal.button.presser.protocol.server.DailyStats
 import sh.zachwal.button.presser.protocol.server.PersonPressing
 import sh.zachwal.button.presser.protocol.server.PersonReleased
 import sh.zachwal.button.presser.protocol.server.ServerMessage
@@ -58,6 +59,8 @@ class Presser constructor(
     private val personReleasedChannel = Channel<String>(10, onBufferOverflow = BufferOverflow.DROP_LATEST)
     // snapshot messages (only need the latest)
     private val snapshotChannel = Channel<Snapshot>(1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+    // daily stats messages (only need the latest)
+    private val dailyStatsChannel = Channel<DailyStats>(1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
 
     suspend fun watchChannels() {
         val incoming = scope.launch {
@@ -86,11 +89,17 @@ class Presser constructor(
                 sendServerMessage(snapshot)
             }
         }
+        val outgoingDailyStats = scope.launch {
+            for (stats in dailyStatsChannel) {
+                sendServerMessage(stats)
+            }
+        }
         incoming.join()
         outgoingCount.join()
         outgoingPerson.join()
         outgoingReleased.join()
         outgoingSnapshot.join()
+        outgoingDailyStats.join()
         observer.disconnected(this)
     }
 
@@ -148,6 +157,10 @@ class Presser constructor(
 
     suspend fun sendSnapshot(snapshot: Snapshot) {
         snapshotChannel.send(snapshot)
+    }
+
+    suspend fun sendDailyStats(stats: DailyStats) {
+        dailyStatsChannel.send(stats)
     }
 
     fun remote(): String = socketSession.call.request.remote()

--- a/src/main/kotlin/sh/zachwal/button/presser/PresserManager.kt
+++ b/src/main/kotlin/sh/zachwal/button/presser/PresserManager.kt
@@ -1,6 +1,7 @@
 package sh.zachwal.button.presser
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder
+import com.google.inject.Inject
 import com.google.inject.Singleton
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
@@ -8,7 +9,9 @@ import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.slf4j.LoggerFactory
+import sh.zachwal.button.presser.protocol.server.DailyStats
 import sh.zachwal.button.presser.protocol.server.Snapshot
+import sh.zachwal.button.presshistory.DailyStatsService
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
 import kotlin.concurrent.thread
@@ -20,7 +23,9 @@ import kotlin.concurrent.thread
  * changes, and it broadcasts relevant updates to all other Presser instances.
  */
 @Singleton
-class PresserManager : PresserObserver {
+class PresserManager @Inject constructor(
+    private val dailyStatsService: DailyStatsService,
+) : PresserObserver {
 
     private val logger = LoggerFactory.getLogger(PresserManager::class.java)
 
@@ -34,7 +39,16 @@ class PresserManager : PresserObserver {
 
     private fun buildSnapshot(): Snapshot {
         val names = currentlyPressing.mapNotNull { it.contact?.name }
-        return Snapshot(count = currentlyPressing.size, names = names)
+        val stats = dailyStatsService.currentStats()
+        return Snapshot(
+            count = currentlyPressing.size,
+            names = names,
+            dailyStats = DailyStats(
+                uniquePressers = stats.uniquePressers,
+                peakConcurrent = stats.peakConcurrent,
+                totalPresses = stats.totalPresses,
+            ),
+        )
     }
 
     init {
@@ -70,10 +84,22 @@ class PresserManager : PresserObserver {
         }
     }
 
+    private suspend fun broadcastDailyStats() {
+        val stats = dailyStatsService.currentStats()
+        val message = DailyStats(
+            uniquePressers = stats.uniquePressers,
+            peakConcurrent = stats.peakConcurrent,
+            totalPresses = stats.totalPresses,
+        )
+        pressers.forEach { it.sendDailyStats(message) }
+    }
+
     override suspend fun pressed(presser: Presser) {
         currentlyPressing.add(presser)
+        dailyStatsService.updatePeak(currentlyPressing.size)
         sendCurrentCount()
         sendNewPresser(presser)
+        broadcastDailyStats()
     }
 
     override suspend fun released(presser: Presser) {
@@ -97,5 +123,13 @@ class PresserManager : PresserObserver {
         pressers.add(presser)
         presser.updatePressingCount(currentlyPressing.count())
         presser.sendSnapshot(buildSnapshot())
+        val stats = dailyStatsService.currentStats()
+        presser.sendDailyStats(
+            DailyStats(
+                uniquePressers = stats.uniquePressers,
+                peakConcurrent = stats.peakConcurrent,
+                totalPresses = stats.totalPresses,
+            )
+        )
     }
 }

--- a/src/main/kotlin/sh/zachwal/button/presser/PresserManager.kt
+++ b/src/main/kotlin/sh/zachwal/button/presser/PresserManager.kt
@@ -96,7 +96,6 @@ class PresserManager @Inject constructor(
 
     override suspend fun pressed(presser: Presser) {
         currentlyPressing.add(presser)
-        dailyStatsService.updatePeak(currentlyPressing.size)
         sendCurrentCount()
         sendNewPresser(presser)
         broadcastDailyStats()

--- a/src/main/kotlin/sh/zachwal/button/presser/protocol/server/DailyStats.kt
+++ b/src/main/kotlin/sh/zachwal/button/presser/protocol/server/DailyStats.kt
@@ -1,0 +1,7 @@
+package sh.zachwal.button.presser.protocol.server
+
+data class DailyStats(
+    val uniquePressers: Int,
+    val peakConcurrent: Int,
+    val totalPresses: Int,
+) : ServerMessage

--- a/src/main/kotlin/sh/zachwal/button/presser/protocol/server/ServerMessage.kt
+++ b/src/main/kotlin/sh/zachwal/button/presser/protocol/server/ServerMessage.kt
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo
     JsonSubTypes.Type(PersonPressing::class),
     JsonSubTypes.Type(PersonReleased::class),
     JsonSubTypes.Type(Snapshot::class),
+    JsonSubTypes.Type(DailyStats::class),
 )
 /**
  * Base interface for all server-to-client protocol messages (e.g., CurrentCount, PersonPressing).

--- a/src/main/kotlin/sh/zachwal/button/presser/protocol/server/Snapshot.kt
+++ b/src/main/kotlin/sh/zachwal/button/presser/protocol/server/Snapshot.kt
@@ -2,5 +2,6 @@ package sh.zachwal.button.presser.protocol.server
 
 data class Snapshot(
     val count: Int,
-    val names: List<String>
+    val names: List<String>,
+    val dailyStats: DailyStats,
 ) : ServerMessage

--- a/src/main/kotlin/sh/zachwal/button/presshistory/DailyStatsService.kt
+++ b/src/main/kotlin/sh/zachwal/button/presshistory/DailyStatsService.kt
@@ -115,7 +115,7 @@ class DailyStatsService @Inject constructor(
         currentlyPressing.remove(presser)
     }
 
-    fun updatePeak(concurrentCount: Int) {
+    private fun updatePeak(concurrentCount: Int) {
         val prevPeak = peakConcurrent.getAndUpdate { max(it, concurrentCount) }
         if (concurrentCount > prevPeak) {
             dbOpChannel.trySend(NewPeak(trackingDate, concurrentCount))

--- a/src/main/kotlin/sh/zachwal/button/presshistory/DailyStatsService.kt
+++ b/src/main/kotlin/sh/zachwal/button/presshistory/DailyStatsService.kt
@@ -20,6 +20,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicInteger
 import javax.inject.Inject
+import javax.inject.Singleton
 import kotlin.concurrent.thread
 import kotlin.math.max
 
@@ -30,6 +31,7 @@ data class NewPress(val date: LocalDate) : DbOp()
 data class NewPeak(val date: LocalDate, val newPeak: Int) : DbOp()
 data class NewPresser(val date: LocalDate, val presserId: String) : DbOp()
 
+@Singleton
 class DailyStatsService @Inject constructor(
     private val dailyStatsDAO: DailyStatsDAO,
     private val dailyPressersDAO: DailyPressersDAO,

--- a/src/test/kotlin/sh/zachwal/button/presser/DailyStatsBroadcastTest.kt
+++ b/src/test/kotlin/sh/zachwal/button/presser/DailyStatsBroadcastTest.kt
@@ -1,0 +1,73 @@
+package sh.zachwal.button.presser
+
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import sh.zachwal.button.presser.protocol.server.DailyStats
+import sh.zachwal.button.presshistory.DailyStatsService
+import sh.zachwal.button.presshistory.DailyStatsSnapshot
+
+class DailyStatsBroadcastTest {
+
+    private val stats = DailyStatsSnapshot(uniquePressers = 3, peakConcurrent = 2, totalPresses = 7)
+    private val dailyStatsService = mockk<DailyStatsService>(relaxed = true).also {
+        every { it.currentStats() } returns stats
+    }
+    private val expectedMessage = DailyStats(
+        uniquePressers = stats.uniquePressers,
+        peakConcurrent = stats.peakConcurrent,
+        totalPresses = stats.totalPresses,
+    )
+
+    @Test
+    fun `addPresser sends current DailyStats to new presser`() = runBlocking {
+        val presser = mockk<Presser>(relaxed = true)
+        every { presser.contact } returns null
+        val manager = PresserManager(dailyStatsService)
+
+        manager.addPresser(presser)
+
+        coVerify { presser.sendDailyStats(expectedMessage) }
+    }
+
+    @Test
+    fun `pressed broadcasts DailyStats to all pressers`() = runBlocking {
+        val presser1 = mockk<Presser>(relaxed = true)
+        val presser2 = mockk<Presser>(relaxed = true)
+        every { presser1.contact } returns null
+        every { presser2.contact } returns null
+        val manager = PresserManager(dailyStatsService)
+        manager.addPresser(presser1)
+        manager.addPresser(presser2)
+
+        manager.pressed(presser1)
+
+        coVerify { presser1.sendDailyStats(expectedMessage) }
+        coVerify { presser2.sendDailyStats(expectedMessage) }
+    }
+
+    @Test
+    fun `pressed broadcasts updated DailyStats after stats change`() = runBlocking {
+        val presser = mockk<Presser>(relaxed = true)
+        every { presser.contact } returns null
+        val manager = PresserManager(dailyStatsService)
+        manager.addPresser(presser)
+
+        val updatedStats = DailyStatsSnapshot(uniquePressers = 4, peakConcurrent = 3, totalPresses = 8)
+        every { dailyStatsService.currentStats() } returns updatedStats
+
+        manager.pressed(presser)
+
+        coVerify {
+            presser.sendDailyStats(
+                DailyStats(
+                    uniquePressers = updatedStats.uniquePressers,
+                    peakConcurrent = updatedStats.peakConcurrent,
+                    totalPresses = updatedStats.totalPresses,
+                )
+            )
+        }
+    }
+}

--- a/src/test/kotlin/sh/zachwal/button/presser/PersonPressingBroadcastTest.kt
+++ b/src/test/kotlin/sh/zachwal/button/presser/PersonPressingBroadcastTest.kt
@@ -6,9 +6,15 @@ import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import sh.zachwal.button.db.jdbi.Contact
+import sh.zachwal.button.presshistory.DailyStatsService
+import sh.zachwal.button.presshistory.DailyStatsSnapshot
 import java.time.Instant
 
 class PersonPressingBroadcastTest {
+    private val dailyStatsService = mockk<DailyStatsService>(relaxed = true).also {
+        every { it.currentStats() } returns DailyStatsSnapshot(0, 0, 0)
+    }
+
     @Test
     fun `broadcasts PersonPressing to all other pressers when a new person presses`() = runBlocking {
         val now = Instant.parse("2025-12-06T16:45:42.742Z")
@@ -18,7 +24,7 @@ class PersonPressingBroadcastTest {
         val presser2 = mockk<Presser>(relaxed = true)
         every { presser1.contact } returns contact1
         every { presser2.contact } returns contact2
-        val manager = PresserManager()
+        val manager = PresserManager(dailyStatsService)
         manager.addPresser(presser1)
         manager.addPresser(presser2)
         // Simulate presser1 pressing
@@ -37,7 +43,7 @@ class PersonPressingBroadcastTest {
         val presser2 = mockk<Presser>(relaxed = true)
         every { presser1.contact } returns contact1
         every { presser2.contact } returns contact2
-        val manager = PresserManager()
+        val manager = PresserManager(dailyStatsService)
         manager.addPresser(presser1)
         manager.addPresser(presser2)
         // Simulate presser1 releasing

--- a/src/test/kotlin/sh/zachwal/button/presser/PresserManagerTest.kt
+++ b/src/test/kotlin/sh/zachwal/button/presser/PresserManagerTest.kt
@@ -1,17 +1,24 @@
 package sh.zachwal.button.presser
 
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.async
 import kotlinx.coroutines.newFixedThreadPoolContext
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import org.junit.jupiter.api.Test
+import sh.zachwal.button.presshistory.DailyStatsService
+import sh.zachwal.button.presshistory.DailyStatsSnapshot
 
 internal class PresserManagerTest {
 
+    private val dailyStatsService = mockk<DailyStatsService>(relaxed = true).also {
+        every { it.currentStats() } returns DailyStatsSnapshot(0, 0, 0)
+    }
+
     @Test
     fun concurrentOperationsTest() {
-        val pm = PresserManager()
+        val pm = PresserManager(dailyStatsService)
         val pressers = (1..100).map { mockk<Presser>(relaxed = true) }
         runBlocking {
             pressers.forEach {

--- a/src/test/kotlin/sh/zachwal/button/presser/PresserTest.kt
+++ b/src/test/kotlin/sh/zachwal/button/presser/PresserTest.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.Test
+import sh.zachwal.button.presser.protocol.server.DailyStats
 import sh.zachwal.button.presser.protocol.server.ServerMessage
 import sh.zachwal.button.presser.protocol.server.Snapshot
 
@@ -44,12 +45,13 @@ class PresserTest {
         val job = launch(Dispatchers.IO) { presser.watchChannels() }
 
         // Send snapshot 1 — coroutine picks it up immediately and blocks on the WebSocket send
-        presser.sendSnapshot(Snapshot(count = 1, names = listOf("old")))
+        val emptyStats = DailyStats(0, 0, 0)
+        presser.sendSnapshot(Snapshot(count = 1, names = listOf("old"), dailyStats = emptyStats))
         firstSendStarted.await() // coroutine is now stuck in send; snapshotChannel is empty
 
         // Fill and overflow the channel while the coroutine is blocked
-        presser.sendSnapshot(Snapshot(count = 2, names = listOf("middle"))) // fills channel (capacity 1)
-        presser.sendSnapshot(Snapshot(count = 3, names = listOf("new"))) // should drop "middle", keep "new"
+        presser.sendSnapshot(Snapshot(count = 2, names = listOf("middle"), dailyStats = emptyStats)) // fills channel (capacity 1)
+        presser.sendSnapshot(Snapshot(count = 3, names = listOf("new"), dailyStats = emptyStats)) // should drop "middle", keep "new"
 
         // Unblock all WebSocket sends
         allowSend.complete(Unit)

--- a/src/test/kotlin/sh/zachwal/button/presser/SnapshotTest.kt
+++ b/src/test/kotlin/sh/zachwal/button/presser/SnapshotTest.kt
@@ -6,22 +6,40 @@ import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import sh.zachwal.button.db.jdbi.Contact
+import sh.zachwal.button.presser.protocol.server.DailyStats
 import sh.zachwal.button.presser.protocol.server.Snapshot
+import sh.zachwal.button.presshistory.DailyStatsService
+import sh.zachwal.button.presshistory.DailyStatsSnapshot
 import java.time.Instant
 
 class SnapshotTest {
 
     private val now = Instant.parse("2025-12-06T16:45:42.742Z")
 
+    private val emptyDailyStats = DailyStatsSnapshot(0, 0, 0)
+    private val dailyStatsService = mockk<DailyStatsService>(relaxed = true).also {
+        every { it.currentStats() } returns emptyDailyStats
+    }
+
+    private fun snapshotWithDailyStats(count: Int, names: List<String>) = Snapshot(
+        count = count,
+        names = names,
+        dailyStats = DailyStats(
+            uniquePressers = emptyDailyStats.uniquePressers,
+            peakConcurrent = emptyDailyStats.peakConcurrent,
+            totalPresses = emptyDailyStats.totalPresses,
+        ),
+    )
+
     @Test
     fun `addPresser sends snapshot to new presser with empty state`() = runBlocking {
         val presser = mockk<Presser>(relaxed = true)
         every { presser.contact } returns null
-        val manager = PresserManager()
+        val manager = PresserManager(dailyStatsService)
 
         manager.addPresser(presser)
 
-        coVerify { presser.sendSnapshot(Snapshot(count = 0, names = emptyList())) }
+        coVerify { presser.sendSnapshot(snapshotWithDailyStats(count = 0, names = emptyList())) }
     }
 
     @Test
@@ -34,7 +52,7 @@ class SnapshotTest {
         val newPresser = mockk<Presser>(relaxed = true)
         every { newPresser.contact } returns null
 
-        val manager = PresserManager()
+        val manager = PresserManager(dailyStatsService)
         manager.addPresser(presser1)
         manager.addPresser(anonymousPresser)
         manager.pressed(presser1)
@@ -42,7 +60,7 @@ class SnapshotTest {
 
         manager.addPresser(newPresser)
 
-        coVerify { newPresser.sendSnapshot(Snapshot(count = 2, names = listOf("Alice"))) }
+        coVerify { newPresser.sendSnapshot(snapshotWithDailyStats(count = 2, names = listOf("Alice"))) }
     }
 
     @Test
@@ -55,7 +73,7 @@ class SnapshotTest {
         val newPresser = mockk<Presser>(relaxed = true)
         every { newPresser.contact } returns null
 
-        val manager = PresserManager()
+        val manager = PresserManager(dailyStatsService)
         manager.addPresser(authenticatedPresser)
         manager.addPresser(anonymousPresser)
         manager.pressed(authenticatedPresser)
@@ -64,6 +82,6 @@ class SnapshotTest {
         manager.addPresser(newPresser)
 
         // count is 2 (both pressing), but names only contains authenticated user
-        coVerify { newPresser.sendSnapshot(Snapshot(count = 2, names = listOf("Alice"))) }
+        coVerify { newPresser.sendSnapshot(snapshotWithDailyStats(count = 2, names = listOf("Alice"))) }
     }
 }

--- a/src/test/kotlin/sh/zachwal/button/presshistory/DailyStatsServiceTest.kt
+++ b/src/test/kotlin/sh/zachwal/button/presshistory/DailyStatsServiceTest.kt
@@ -99,21 +99,6 @@ class DailyStatsServiceTest(private val jdbi: Jdbi) {
     }
 
     @Test
-    fun `updatePeak with higher count updates peak`() {
-        service.updatePeak(5)
-
-        assertThat(service.currentStats().peakConcurrent).isEqualTo(5)
-    }
-
-    @Test
-    fun `updatePeak with lower count does not lower existing peak`() {
-        service.updatePeak(5)
-        service.updatePeak(3)
-
-        assertThat(service.currentStats().peakConcurrent).isEqualTo(5)
-    }
-
-    @Test
     fun `peak concurrent rises as more pressers press simultaneously`() = runBlocking {
         val presserA = mockPresser("1.1.1.1")
         val presserB = mockPresser("2.2.2.2")


### PR DESCRIPTION
## Summary
- Adds `DailyStats` ServerMessage (new protocol message with `uniquePressers`, `peakConcurrent`, `totalPresses`)
- Registers `DailyStats` in `@JsonSubTypes` and adds it as a field on `Snapshot`
- Wires `DailyStatsService` into `PresserManager`: broadcasts `DailyStats` on every press, sends to new connections, and bundles into periodic `Snapshot`

## Test plan
- [ ] `./gradlew build` passes (presser tests all green; DB tests require Docker)
- [ ] Manual: open two browser tabs, press in one — verify WS frames contain `DailyStats` messages in both tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)