### PR TITLE
Daily stats PR 4: Frontend display

### DIFF
--- a/frontend/src/__tests__/js/bootstrap/main.test.js
+++ b/frontend/src/__tests__/js/bootstrap/main.test.js
@@ -130,8 +130,8 @@ describe('bootstrap/main', () => {
       dailyStats: { uniquePressers: 4, peakConcurrent: 2, totalPresses: 17 }
     });
 
-    expect(document.getElementById('dailyStats').innerText).toBe('4 pressers today · 2 at once · 17 presses');
-    expect(document.getElementById('dailyStatsWhite').innerText).toBe('4 pressers today · 2 at once · 17 presses');
+    expect(document.getElementById('dailyStats').innerText).toBe('4 pressers today · 2 max at once · 17 presses');
+    expect(document.getElementById('dailyStatsWhite').innerText).toBe('4 pressers today · 2 max at once · 17 presses');
   });
 
   it('DailyStats message updates daily stats DOM elements', async () => {
@@ -144,8 +144,8 @@ describe('bootstrap/main', () => {
 
     socket.handlers.onDailyStats({ type: 'DailyStats', uniquePressers: 4, peakConcurrent: 2, totalPresses: 17 });
 
-    expect(document.getElementById('dailyStats').innerText).toBe('4 pressers today · 2 at once · 17 presses');
-    expect(document.getElementById('dailyStatsWhite').innerText).toBe('4 pressers today · 2 at once · 17 presses');
+    expect(document.getElementById('dailyStats').innerText).toBe('4 pressers today · 2 max at once · 17 presses');
+    expect(document.getElementById('dailyStatsWhite').innerText).toBe('4 pressers today · 2 max at once · 17 presses');
   });
 
   it('setDailyStats uses singular presser and press for counts of 1', async () => {
@@ -155,7 +155,7 @@ describe('bootstrap/main', () => {
 
     socket.handlers.onDailyStats({ type: 'DailyStats', uniquePressers: 1, peakConcurrent: 1, totalPresses: 1 });
 
-    expect(document.getElementById('dailyStats').innerText).toBe('1 presser today · 1 at once · 1 press');
+    expect(document.getElementById('dailyStats').innerText).toBe('1 presser today · 1 press');
   });
 
   it('setDailyStats does not throw if DOM nodes are missing', async () => {

--- a/frontend/src/__tests__/js/bootstrap/main.test.js
+++ b/frontend/src/__tests__/js/bootstrap/main.test.js
@@ -117,6 +117,52 @@ describe('bootstrap/main', () => {
     expect(document.getElementById('buttonPressCountWhite').innerText).toBe('BUTTON PRESSERS: 5');
   });
 
+  it('Snapshot updates daily stats DOM elements', async () => {
+    document.body.innerHTML = `
+      <div id="dailyStats"></div>
+      <div id="dailyStatsWhite"></div>
+    `;
+
+    const socket = await loadModule();
+
+    socket.handlers.onSnapshot({
+      type: 'Snapshot', count: 0, names: [],
+      dailyStats: { uniquePressers: 4, peakConcurrent: 2, totalPresses: 17 }
+    });
+
+    expect(document.getElementById('dailyStats').innerText).toBe('4 pressers today · peak 2 · 17 presses');
+    expect(document.getElementById('dailyStatsWhite').innerText).toBe('4 pressers today · peak 2 · 17 presses');
+  });
+
+  it('DailyStats message updates daily stats DOM elements', async () => {
+    document.body.innerHTML = `
+      <div id="dailyStats"></div>
+      <div id="dailyStatsWhite"></div>
+    `;
+
+    const socket = await loadModule();
+
+    socket.handlers.onDailyStats({ type: 'DailyStats', uniquePressers: 4, peakConcurrent: 2, totalPresses: 17 });
+
+    expect(document.getElementById('dailyStats').innerText).toBe('4 pressers today · peak 2 · 17 presses');
+    expect(document.getElementById('dailyStatsWhite').innerText).toBe('4 pressers today · peak 2 · 17 presses');
+  });
+
+  it('setDailyStats uses singular presser and press for counts of 1', async () => {
+    document.body.innerHTML = `<div id="dailyStats"></div>`;
+
+    const socket = await loadModule();
+
+    socket.handlers.onDailyStats({ type: 'DailyStats', uniquePressers: 1, peakConcurrent: 1, totalPresses: 1 });
+
+    expect(document.getElementById('dailyStats').innerText).toBe('1 presser today · peak 1 · 1 press');
+  });
+
+  it('setDailyStats does not throw if DOM nodes are missing', async () => {
+    const socket = await loadModule();
+    expect(() => socket.handlers.onDailyStats({ type: 'DailyStats', uniquePressers: 1, peakConcurrent: 1, totalPresses: 1 })).not.toThrow();
+  });
+
   it('Snapshot with empty names clears all pressers', async () => {
     const socket = await loadModule();
 

--- a/frontend/src/__tests__/js/bootstrap/main.test.js
+++ b/frontend/src/__tests__/js/bootstrap/main.test.js
@@ -130,8 +130,8 @@ describe('bootstrap/main', () => {
       dailyStats: { uniquePressers: 4, peakConcurrent: 2, totalPresses: 17 }
     });
 
-    expect(document.getElementById('dailyStats').innerText).toBe('4 pressers today · peak 2 · 17 presses');
-    expect(document.getElementById('dailyStatsWhite').innerText).toBe('4 pressers today · peak 2 · 17 presses');
+    expect(document.getElementById('dailyStats').innerText).toBe('4 pressers today · 2 at once · 17 presses');
+    expect(document.getElementById('dailyStatsWhite').innerText).toBe('4 pressers today · 2 at once · 17 presses');
   });
 
   it('DailyStats message updates daily stats DOM elements', async () => {
@@ -144,8 +144,8 @@ describe('bootstrap/main', () => {
 
     socket.handlers.onDailyStats({ type: 'DailyStats', uniquePressers: 4, peakConcurrent: 2, totalPresses: 17 });
 
-    expect(document.getElementById('dailyStats').innerText).toBe('4 pressers today · peak 2 · 17 presses');
-    expect(document.getElementById('dailyStatsWhite').innerText).toBe('4 pressers today · peak 2 · 17 presses');
+    expect(document.getElementById('dailyStats').innerText).toBe('4 pressers today · 2 at once · 17 presses');
+    expect(document.getElementById('dailyStatsWhite').innerText).toBe('4 pressers today · 2 at once · 17 presses');
   });
 
   it('setDailyStats uses singular presser and press for counts of 1', async () => {
@@ -155,7 +155,7 @@ describe('bootstrap/main', () => {
 
     socket.handlers.onDailyStats({ type: 'DailyStats', uniquePressers: 1, peakConcurrent: 1, totalPresses: 1 });
 
-    expect(document.getElementById('dailyStats').innerText).toBe('1 presser today · peak 1 · 1 press');
+    expect(document.getElementById('dailyStats').innerText).toBe('1 presser today · 1 at once · 1 press');
   });
 
   it('setDailyStats does not throw if DOM nodes are missing', async () => {

--- a/frontend/src/__tests__/js/net/socket.test.js
+++ b/frontend/src/__tests__/js/net/socket.test.js
@@ -117,6 +117,18 @@ describe('net/socket', () => {
     socket.close();
   });
 
+  it('dispatches DailyStats messages to onDailyStats handler', () => {
+    const onDailyStats = vi.fn();
+    const socket = new Socket({ url: 'ws://example', handlers: { onDailyStats } });
+    const ws = FakeWebSocket.instances[0];
+
+    ws.emitMessage({ type: 'DailyStats', uniquePressers: 4, peakConcurrent: 2, totalPresses: 17 });
+
+    expect(onDailyStats).toHaveBeenCalledWith({ type: 'DailyStats', uniquePressers: 4, peakConcurrent: 2, totalPresses: 17 });
+
+    socket.close();
+  });
+
   it('ignores bad JSON from server', () => {
     const handlers = {
       onCurrentCount: vi.fn(),

--- a/frontend/src/main/css/style.css
+++ b/frontend/src/main/css/style.css
@@ -93,6 +93,15 @@ button:active {
     color: white;
 }
 
+.dailyStatsText {
+    font-size: 0.9em;
+    opacity: 0.6;
+    margin-top: 0.25em;
+    text-align: center;
+    font-family: Avenir, Arial, sans-serif;
+    font-weight: 700;
+}
+
 #signup {
     color: #721c24;
     background-color: #f8d7da;

--- a/frontend/src/main/js/bootstrap/main.js
+++ b/frontend/src/main/js/bootstrap/main.js
@@ -16,7 +16,7 @@ function setPresserCount(n) {
 function setDailyStats({ uniquePressers, peakConcurrent, totalPresses }) {
     const presserWord = uniquePressers === 1 ? 'presser' : 'pressers';
     const pressWord = totalPresses === 1 ? 'press' : 'presses';
-    const text = `${uniquePressers} ${presserWord} today · peak ${peakConcurrent} · ${totalPresses} ${pressWord}`;
+    const text = `${uniquePressers} ${presserWord} today · ${peakConcurrent} at once · ${totalPresses} ${pressWord}`;
     const el = document.getElementById('dailyStats');
     const elWhite = document.getElementById('dailyStatsWhite');
     if (el) el.innerText = text;

--- a/frontend/src/main/js/bootstrap/main.js
+++ b/frontend/src/main/js/bootstrap/main.js
@@ -13,6 +13,16 @@ function setPresserCount(n) {
     if (buttonPressDivWhite) buttonPressDivWhite.innerText = "BUTTON PRESSERS: " + n;
 }
 
+function setDailyStats({ uniquePressers, peakConcurrent, totalPresses }) {
+    const presserWord = uniquePressers === 1 ? 'presser' : 'pressers';
+    const pressWord = totalPresses === 1 ? 'press' : 'presses';
+    const text = `${uniquePressers} ${presserWord} today · peak ${peakConcurrent} · ${totalPresses} ${pressWord}`;
+    const el = document.getElementById('dailyStats');
+    const elWhite = document.getElementById('dailyStatsWhite');
+    if (el) el.innerText = text;
+    if (elWhite) elWhite.innerText = text;
+}
+
 const socket = new Socket({
     url: wsUrl, // injected by HomeController
     handlers: {
@@ -34,7 +44,9 @@ const socket = new Socket({
             msg.names.forEach(name => currentPressers.add(name));
             renderFloatingPressers(Array.from(currentPressers));
             setPresserCount(msg.count);
-        }
+            if (msg.dailyStats) setDailyStats(msg.dailyStats);
+        },
+        onDailyStats: (msg) => setDailyStats(msg)
     }
 });
 

--- a/frontend/src/main/js/bootstrap/main.js
+++ b/frontend/src/main/js/bootstrap/main.js
@@ -16,7 +16,8 @@ function setPresserCount(n) {
 function setDailyStats({ uniquePressers, peakConcurrent, totalPresses }) {
     const presserWord = uniquePressers === 1 ? 'presser' : 'pressers';
     const pressWord = totalPresses === 1 ? 'press' : 'presses';
-    const text = `${uniquePressers} ${presserWord} today · ${peakConcurrent} at once · ${totalPresses} ${pressWord}`;
+    const peakSegment = uniquePressers > 1 ? ` · ${peakConcurrent} max at once` : '';
+    const text = `${uniquePressers} ${presserWord} today${peakSegment} · ${totalPresses} ${pressWord}`;
     const el = document.getElementById('dailyStats');
     const elWhite = document.getElementById('dailyStatsWhite');
     if (el) el.innerText = text;

--- a/frontend/src/main/js/net/socket.js
+++ b/frontend/src/main/js/net/socket.js
@@ -13,6 +13,7 @@ class Socket {
     this.onPersonPressing = handlers.onPersonPressing || function() {};
     this.onPersonReleased = handlers.onPersonReleased || function() {};
     this.onSnapshot = handlers.onSnapshot || function() {};
+    this.onDailyStats = handlers.onDailyStats || function() {};
 
     this.BACKOFF_INITIAL = 1000;
     this.BACKOFF_FACTOR = 1.5;
@@ -91,6 +92,9 @@ class Socket {
         break;
       case 'Snapshot':
         this.onSnapshot(msg);
+        break;
+      case 'DailyStats':
+        this.onDailyStats(msg);
         break;
       default:
         console.error('Unknown message type received from server: ', msg.type);

--- a/src/main/kotlin/sh/zachwal/button/home/HomeController.kt
+++ b/src/main/kotlin/sh/zachwal/button/home/HomeController.kt
@@ -162,10 +162,16 @@ class HomeController @Inject constructor(
                                     id = "buttonPressCountWhite"
                                     +"BUTTON PRESSERS: 0"
                                 }
+                                div(classes = "dailyStatsText whiteButton") {
+                                    id = "dailyStatsWhite"
+                                }
                             } else {
                                 h1 {
                                     id = "buttonPressCount"
                                     +"BUTTON PRESSERS: 0"
+                                }
+                                div(classes = "dailyStatsText") {
+                                    id = "dailyStats"
                                 }
                             }
                         }

--- a/src/main/kotlin/sh/zachwal/button/presser/Presser.kt
+++ b/src/main/kotlin/sh/zachwal/button/presser/Presser.kt
@@ -62,6 +62,7 @@ class Presser constructor(
 
     // snapshot messages (only need the latest)
     private val snapshotChannel = Channel<Snapshot>(1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+
     // daily stats messages (only need the latest)
     private val dailyStatsChannel = Channel<DailyStats>(1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
 


### PR DESCRIPTION
## Summary
- Adds `#dailyStats` / `#dailyStatsWhite` elements below the presser count heading in `HomeController`
- Handles `DailyStats` WebSocket message in `socket.js` and `main.js`; also reads `dailyStats` from `Snapshot`
- Formats text as `N presser(s) today · peak N · N press(es)` with correct singular/plural
- Styles the line at `0.9em`, `opacity: 0.6`, centered below the heading

## Test plan
- [ ] `npm --prefix frontend test` — all 50 tests pass
- [ ] `./gradlew build` — clean build
- [ ] Load the page and verify stats appear below the counter on first WebSocket message

🤖 Generated with [Claude Code](https://claude.com/claude-code)