### PR TITLE
Consolidate outgoing channels to two Channel<ServerMessage> by overflow type

### DIFF
--- a/src/main/kotlin/sh/zachwal/button/presser/Presser.kt
+++ b/src/main/kotlin/sh/zachwal/button/presser/Presser.kt
@@ -51,19 +51,11 @@ class Presser constructor(
     // uses two coroutines, one to accept incoming & one to send outgoing
     private val scope = CoroutineScope(dispatcher)
 
-    // updates to the current count of pressers
-    private val countUpdateChannel = Channel<Int>(10, onBufferOverflow = BufferOverflow.DROP_LATEST)
+    // high-volume messages where we drop new arrivals if the buffer fills
+    private val dropLatestChannel = Channel<ServerMessage>(10, onBufferOverflow = BufferOverflow.DROP_LATEST)
 
-    // person pressing notifications
-    private val personPressingChannel = Channel<String>(10, onBufferOverflow = BufferOverflow.DROP_LATEST)
-
-    // person released notifications
-    private val personReleasedChannel = Channel<String>(10, onBufferOverflow = BufferOverflow.DROP_LATEST)
-
-    // snapshot messages (only need the latest)
-    private val snapshotChannel = Channel<Snapshot>(1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
-    // daily stats messages (only need the latest)
-    private val dailyStatsChannel = Channel<DailyStats>(1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+    // state snapshot messages where we only need the latest; capacity 2 so Snapshot and DailyStats can coexist
+    private val dropOldestChannel = Channel<ServerMessage>(2, onBufferOverflow = BufferOverflow.DROP_OLDEST)
 
     suspend fun watchChannels() {
         val incoming = scope.launch {
@@ -72,37 +64,19 @@ class Presser constructor(
                 handleIncomingFrame(frame)
             }
         }
-        val outgoingCount = scope.launch {
-            for (updatedCount in countUpdateChannel) {
-                sendServerMessage(CurrentCount(count = updatedCount))
+        val outgoingDropLatest = scope.launch {
+            for (message in dropLatestChannel) {
+                sendServerMessage(message)
             }
         }
-        val outgoingPerson = scope.launch {
-            for (name in personPressingChannel) {
-                sendServerMessage(PersonPressing(displayName = name))
-            }
-        }
-        val outgoingReleased = scope.launch {
-            for (name in personReleasedChannel) {
-                sendServerMessage(PersonReleased(displayName = name))
-            }
-        }
-        val outgoingSnapshot = scope.launch {
-            for (snapshot in snapshotChannel) {
-                sendServerMessage(snapshot)
-            }
-        }
-        val outgoingDailyStats = scope.launch {
-            for (stats in dailyStatsChannel) {
-                sendServerMessage(stats)
+        val outgoingDropOldest = scope.launch {
+            for (message in dropOldestChannel) {
+                sendServerMessage(message)
             }
         }
         incoming.join()
-        outgoingCount.join()
-        outgoingPerson.join()
-        outgoingReleased.join()
-        outgoingSnapshot.join()
-        outgoingDailyStats.join()
+        outgoingDropLatest.join()
+        outgoingDropOldest.join()
         observer.disconnected(this)
     }
 
@@ -147,23 +121,23 @@ class Presser constructor(
     }
 
     suspend fun updatePressingCount(count: Int) {
-        countUpdateChannel.send(count)
+        dropLatestChannel.send(CurrentCount(count = count))
     }
 
     suspend fun notifyPersonPressing(name: String) {
-        personPressingChannel.send(name)
+        dropLatestChannel.send(PersonPressing(displayName = name))
     }
 
     suspend fun notifyPersonReleased(name: String) {
-        personReleasedChannel.send(name)
+        dropLatestChannel.send(PersonReleased(displayName = name))
     }
 
     suspend fun sendSnapshot(snapshot: Snapshot) {
-        snapshotChannel.send(snapshot)
+        dropOldestChannel.send(snapshot)
     }
 
     suspend fun sendDailyStats(stats: DailyStats) {
-        dailyStatsChannel.send(stats)
+        dropOldestChannel.send(stats)
     }
 
     fun remote(): String = socketSession.call.request.remote()

--- a/src/test/kotlin/sh/zachwal/button/presser/PresserTest.kt
+++ b/src/test/kotlin/sh/zachwal/button/presser/PresserTest.kt
@@ -26,7 +26,7 @@ class PresserTest {
     private val mapper = jacksonObjectMapper().registerModule(JavaTimeModule())
 
     @Test
-    fun `newer snapshot overwrites older when snapshot channel is full`() = runBlocking {
+    fun `oldest snapshot is dropped when drop-oldest channel overflows`() = runBlocking {
         val session = mockk<WebSocketServerSession>(relaxed = true)
         every { session.incoming } returns Channel<Frame>() // never produces frames
 
@@ -46,12 +46,13 @@ class PresserTest {
 
         // Send snapshot 1 — coroutine picks it up immediately and blocks on the WebSocket send
         val emptyStats = DailyStats(0, 0, 0)
-        presser.sendSnapshot(Snapshot(count = 1, names = listOf("old"), dailyStats = emptyStats))
-        firstSendStarted.await() // coroutine is now stuck in send; snapshotChannel is empty
+        presser.sendSnapshot(Snapshot(count = 1, names = listOf("s1"), dailyStats = emptyStats))
+        firstSendStarted.await() // coroutine is now stuck in send; channel is empty
 
-        // Fill and overflow the channel while the coroutine is blocked
-        presser.sendSnapshot(Snapshot(count = 2, names = listOf("middle"), dailyStats = emptyStats)) // fills channel (capacity 1)
-        presser.sendSnapshot(Snapshot(count = 3, names = listOf("new"), dailyStats = emptyStats)) // should drop "middle", keep "new"
+        // Fill the channel to capacity (2) then overflow it while the coroutine is blocked
+        presser.sendSnapshot(Snapshot(count = 2, names = listOf("s2"), dailyStats = emptyStats)) // fills slot 1
+        presser.sendSnapshot(Snapshot(count = 3, names = listOf("s3"), dailyStats = emptyStats)) // fills slot 2
+        presser.sendSnapshot(Snapshot(count = 4, names = listOf("s4"), dailyStats = emptyStats)) // overflows: drops s2, keeps s3+s4
 
         // Unblock all WebSocket sends
         allowSend.complete(Unit)
@@ -59,12 +60,17 @@ class PresserTest {
         // First message sent: snapshot 1 (was already picked up before the block)
         val firstSent = mapper.readValue<ServerMessage>(withTimeout(1000) { sentTexts.receive() })
         assertThat(firstSent).isInstanceOf(Snapshot::class.java)
-        assertThat((firstSent as Snapshot).names).containsExactly("old")
+        assertThat((firstSent as Snapshot).names).containsExactly("s1")
 
-        // Second message sent: should be snapshot 3 ("new"), not snapshot 2 ("middle")
+        // Second message sent: s3, because s2 (oldest queued) was dropped
         val secondSent = mapper.readValue<ServerMessage>(withTimeout(1000) { sentTexts.receive() })
         assertThat(secondSent).isInstanceOf(Snapshot::class.java)
-        assertThat((secondSent as Snapshot).names).containsExactly("new")
+        assertThat((secondSent as Snapshot).names).containsExactly("s3")
+
+        // Third message sent: s4
+        val thirdSent = mapper.readValue<ServerMessage>(withTimeout(1000) { sentTexts.receive() })
+        assertThat(thirdSent).isInstanceOf(Snapshot::class.java)
+        assertThat((thirdSent as Snapshot).names).containsExactly("s4")
 
         job.cancel()
     }


### PR DESCRIPTION
## Summary

- Replaces five typed channels (`countUpdateChannel`, `personPressingChannel`, `personReleasedChannel`, `snapshotChannel`, `dailyStatsChannel`) with two `Channel<ServerMessage>` channels differentiated by overflow behavior
- `dropLatestChannel` (capacity 10, DROP_LATEST) handles `CurrentCount`, `PersonPressing`, `PersonReleased`
- `dropOldestChannel` (capacity 2, DROP_OLDEST) handles `Snapshot` and `DailyStats`; capacity 2 lets both types coexist in the buffer without evicting each other
- The five `launch` blocks in `watchChannels` shrink to two; public API methods now construct the `ServerMessage` before sending

## Test plan

- [ ] `PresserTest` updated to test the DROP_OLDEST overflow at capacity 2 (sends 4 snapshots, verifies s2 is dropped and s3+s4 are delivered)
- [ ] All presser tests pass: `./gradlew test --tests "sh.zachwal.button.presser.*"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)