### PR TITLE
Add midnight rollover timer to DailyStatsService

### DIFF
--- a/src/main/kotlin/sh/zachwal/button/presshistory/DailyStatsService.kt
+++ b/src/main/kotlin/sh/zachwal/button/presshistory/DailyStatsService.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
@@ -35,6 +36,7 @@ data class NewPresser(val date: LocalDate, val presserId: String) : DbOp()
 class DailyStatsService @Inject constructor(
     private val dailyStatsDAO: DailyStatsDAO,
     private val dailyPressersDAO: DailyPressersDAO,
+    private val rolloverCheckIntervalMs: Long = 60_000L,
 ) : PresserObserver {
 
     private val logger = LoggerFactory.getLogger(DailyStatsService::class.java)
@@ -67,6 +69,21 @@ class DailyStatsService @Inject constructor(
                 processDbOp(op)
             } catch (e: Exception) {
                 logger.error("Failed to process DB op: $op", e)
+            }
+        }
+    }
+
+    private val rolloverCheckJob: Job = scope.launch {
+        while (true) {
+            delay(rolloverCheckIntervalMs)
+            try {
+                val today = LocalDate.now(clock)
+                if (today != trackingDate) {
+                    logger.info("Day rolled over to $today, reinitializing stats")
+                    initialize()
+                }
+            } catch (e: Exception) {
+                logger.error("Failed to check for day rollover", e)
             }
         }
     }
@@ -131,6 +148,7 @@ class DailyStatsService @Inject constructor(
     )
 
     fun close() {
+        rolloverCheckJob.cancel()
         dbOpChannel.close()
         runBlocking { consumerJob.join() } // drain remaining ops before stopping the thread pool
         threadPool.shutdown()

--- a/src/test/kotlin/sh/zachwal/button/presshistory/DailyStatsServiceTest.kt
+++ b/src/test/kotlin/sh/zachwal/button/presshistory/DailyStatsServiceTest.kt
@@ -3,6 +3,7 @@ package sh.zachwal.button.presshistory
 import com.google.common.truth.Truth.assertThat
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.sqlobject.kotlin.onDemand
@@ -224,6 +225,29 @@ class DailyStatsServiceTest(private val jdbi: Jdbi) {
         val stats = service.currentStats()
         assertThat(stats.totalPresses).isEqualTo(3)
         assertThat(stats.uniquePressers).isEqualTo(2)
+    }
+
+    @Test
+    fun `timer triggers midnight rollover without a press`() = runBlocking {
+        // Close the 60s-interval service and create one with a short check interval
+        service.close()
+        service = DailyStatsService(dailyStatsDAO, dailyPressersDAO, rolloverCheckIntervalMs = 50L)
+
+        // Build up some stats for today
+        service.pressed(mockPresser("1.2.3.4"))
+        service.pressed(mockPresser("5.6.7.8"))
+        assertThat(service.currentStats().totalPresses).isEqualTo(2)
+
+        // Advance the clock to tomorrow — timer will trigger rollover on next check
+        service.clock = clockFor(today.plusDays(1))
+
+        // Wait for the timer to fire
+        delay(200L)
+
+        val stats = service.currentStats()
+        assertThat(stats.totalPresses).isEqualTo(0)
+        assertThat(stats.uniquePressers).isEqualTo(0)
+        assertThat(stats.peakConcurrent).isEqualTo(0)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- `currentStats()` was returning stale data from the last press day if no one pressed after midnight — the rollover only fired on a `pressed()` event
- Adds a periodic coroutine (every 60s) that calls `initialize()` when the date changes, independent of any user activity
- `rolloverCheckIntervalMs` is a constructor parameter (default 60s) to keep tests fast; `close()` cancels the job cleanly

## Test plan

- [x] New test: `timer triggers midnight rollover without a press` — creates a service with 50ms check interval, advances the clock to tomorrow, waits 200ms, asserts stats reset to zero
- [x] All 14 existing `DailyStatsServiceTest` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)