### PR TITLE
Add midnight rollover timer to DailyStatsService

### DIFF
--- a/src/main/kotlin/sh/zachwal/button/guice/ApplicationModule.kt
+++ b/src/main/kotlin/sh/zachwal/button/guice/ApplicationModule.kt
@@ -6,6 +6,8 @@ import com.google.inject.Singleton
 import com.google.inject.name.Named
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.asCoroutineDispatcher
+import sh.zachwal.button.presshistory.DailyStatsConfig
+import java.time.Clock
 import java.util.concurrent.Executors
 
 class ApplicationModule : AbstractModule() {
@@ -15,4 +17,11 @@ class ApplicationModule : AbstractModule() {
     @Named("presserDispatcher")
     fun presserDispatcher(): CoroutineDispatcher = Executors.newFixedThreadPool(4)
         .asCoroutineDispatcher()
+
+    @Provides
+    @Singleton
+    fun dailyStatsConfig(): DailyStatsConfig = DailyStatsConfig(
+        clock = Clock.systemDefaultZone(),
+        rolloverCheckIntervalMs = 500L,
+    )
 }

--- a/src/main/kotlin/sh/zachwal/button/presshistory/DailyStatsService.kt
+++ b/src/main/kotlin/sh/zachwal/button/presshistory/DailyStatsService.kt
@@ -18,6 +18,7 @@ import java.time.Clock
 import java.time.LocalDate
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -25,6 +26,11 @@ import kotlin.concurrent.thread
 import kotlin.math.max
 
 data class DailyStatsSnapshot(val uniquePressers: Int, val peakConcurrent: Int, val totalPresses: Int)
+
+data class DailyStatsConfig(
+    val clock: Clock,
+    val rolloverCheckIntervalMs: Long,
+)
 
 sealed class DbOp
 data class NewPress(val date: LocalDate) : DbOp()
@@ -35,11 +41,12 @@ data class NewPresser(val date: LocalDate, val presserId: String) : DbOp()
 class DailyStatsService @Inject constructor(
     private val dailyStatsDAO: DailyStatsDAO,
     private val dailyPressersDAO: DailyPressersDAO,
+    private val config: DailyStatsConfig,
 ) : PresserObserver {
 
     private val logger = LoggerFactory.getLogger(DailyStatsService::class.java)
 
-    internal var clock: Clock = Clock.systemDefaultZone()
+    private val clock: Clock get() = config.clock
 
     private val uniquePresserIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
     private val currentlyPressing: MutableSet<Presser> = ConcurrentHashMap.newKeySet()
@@ -56,10 +63,11 @@ class DailyStatsService @Inject constructor(
         logger.error("Dropping a database write due to a buffer overflow: $undeliveredDbOp")
     }
 
-    private val threadPool = Executors.newSingleThreadExecutor(
+    // Single-threaded pool for DB writes (consumer of dbOpChannel)
+    private val dbThreadPool = Executors.newSingleThreadExecutor(
         ThreadFactoryBuilder().setNameFormat("daily-stats-db-%d").build()
     )
-    private val scope = CoroutineScope(threadPool.asCoroutineDispatcher() + SupervisorJob())
+    private val scope = CoroutineScope(dbThreadPool.asCoroutineDispatcher() + SupervisorJob())
 
     private val consumerJob: Job = scope.launch {
         for (op in dbOpChannel) {
@@ -71,17 +79,68 @@ class DailyStatsService @Inject constructor(
         }
     }
 
+    // Separate single-threaded pool for the midnight rollover timer — must not share
+    // threads with the DB pool so a slow DB write never delays the rollover check.
+    private val rolloverThreadPool = Executors.newSingleThreadScheduledExecutor(
+        ThreadFactoryBuilder().setNameFormat("daily-stats-rollover-%d").build()
+    )
+
     init {
         Runtime.getRuntime().addShutdownHook(
-            thread(start = false) { threadPool.shutdownNow() }
+            thread(start = false) {
+                rolloverThreadPool.shutdownNow()
+                dbThreadPool.shutdownNow()
+            }
         )
         initialize()
+        rolloverThreadPool.scheduleAtFixedRate(
+            ::checkRollover,
+            config.rolloverCheckIntervalMs,
+            config.rolloverCheckIntervalMs,
+            TimeUnit.MILLISECONDS,
+        )
     }
 
+    /**
+     * Loads stats for the current day from the DB. Called on fresh boot.
+     * Does not account for any users who may currently be pressing.
+     */
     fun initialize() {
+        loadNewDay(LocalDate.now(clock))
+    }
+
+    /**
+     * Rolls over to a new day. Resets in-memory stats, reloads from DB, and carries
+     * currently-pressing users into the new day as unique pressers and initial peak.
+     * Called both by the periodic timer and by [pressed] when a press detects a date change.
+     */
+    internal fun rollover() {
+        val newDay = LocalDate.now(clock)
+        val pressersAtRollover = currentlyPressing.toSet()
+        loadNewDay(newDay)
+
+        for (presser in pressersAtRollover) {
+            val presserId = presser.contact?.id?.toString() ?: presser.remoteHost
+            val isNew = uniquePresserIds.add(presserId)
+            if (isNew) {
+                dbOpChannel.trySend(NewPresser(newDay, presserId))
+            }
+        }
+        if (pressersAtRollover.isNotEmpty()) {
+            updatePeak(pressersAtRollover.size)
+        }
+    }
+
+    private fun checkRollover() {
         val today = LocalDate.now(clock)
-        dailyStatsDAO.ensureRow(today)
-        val row = dailyStatsDAO.findByDate(today)
+        if (today != trackingDate) {
+            rollover()
+        }
+    }
+
+    private fun loadNewDay(date: LocalDate) {
+        dailyStatsDAO.ensureRow(date)
+        val row = dailyStatsDAO.findByDate(date)
         uniquePresserIds.clear()
         peakConcurrent.set(0)
         totalPressCount.set(0)
@@ -89,14 +148,14 @@ class DailyStatsService @Inject constructor(
             peakConcurrent.set(row.peakConcurrent)
             totalPressCount.set(row.totalPressCount)
         }
-        uniquePresserIds.addAll(dailyPressersDAO.findByDate(today))
-        trackingDate = today
+        uniquePresserIds.addAll(dailyPressersDAO.findByDate(date))
+        trackingDate = date
     }
 
     override suspend fun pressed(presser: Presser) {
         val today = LocalDate.now(clock)
         if (today != trackingDate) {
-            initialize()
+            rollover()
         }
         currentlyPressing.add(presser)
         updatePeak(currentlyPressing.size)
@@ -131,9 +190,11 @@ class DailyStatsService @Inject constructor(
     )
 
     fun close() {
+        rolloverThreadPool.shutdown()
+        rolloverThreadPool.awaitTermination(5, TimeUnit.SECONDS)
         dbOpChannel.close()
         runBlocking { consumerJob.join() } // drain remaining ops before stopping the thread pool
-        threadPool.shutdown()
+        dbThreadPool.shutdown()
     }
 
     private fun processDbOp(op: DbOp) {

--- a/src/main/kotlin/sh/zachwal/button/presshistory/DailyStatsService.kt
+++ b/src/main/kotlin/sh/zachwal/button/presshistory/DailyStatsService.kt
@@ -45,8 +45,9 @@ class DailyStatsService @Inject constructor(
 ) : PresserObserver {
 
     private val logger = LoggerFactory.getLogger(DailyStatsService::class.java)
-
     private val clock: Clock get() = config.clock
+
+    // --- In-memory state ---
 
     private val uniquePresserIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
     private val currentlyPressing: MutableSet<Presser> = ConcurrentHashMap.newKeySet()
@@ -55,6 +56,8 @@ class DailyStatsService @Inject constructor(
 
     @Volatile
     private var trackingDate: LocalDate = LocalDate.now(clock)
+
+    // --- Async DB write infrastructure ---
 
     private val dbOpChannel = Channel<DbOp>(
         capacity = 1000,
@@ -68,7 +71,6 @@ class DailyStatsService @Inject constructor(
         ThreadFactoryBuilder().setNameFormat("daily-stats-db-%d").build()
     )
     private val scope = CoroutineScope(dbThreadPool.asCoroutineDispatcher() + SupervisorJob())
-
     private val consumerJob: Job = scope.launch {
         for (op in dbOpChannel) {
             try {
@@ -79,8 +81,8 @@ class DailyStatsService @Inject constructor(
         }
     }
 
-    // Separate single-threaded pool for the midnight rollover timer — must not share
-    // threads with the DB pool so a slow DB write never delays the rollover check.
+    // Separate pool for the midnight rollover timer — must not share threads with the DB
+    // pool so a slow DB write never delays the rollover check.
     private val rolloverThreadPool = Executors.newSingleThreadScheduledExecutor(
         ThreadFactoryBuilder().setNameFormat("daily-stats-rollover-%d").build()
     )
@@ -101,6 +103,8 @@ class DailyStatsService @Inject constructor(
         )
     }
 
+    // --- Lifecycle ---
+
     /**
      * Loads stats for the current day from the DB. Called on fresh boot.
      * Does not account for any users who may currently be pressing.
@@ -109,48 +113,15 @@ class DailyStatsService @Inject constructor(
         loadNewDay(LocalDate.now(clock))
     }
 
-    /**
-     * Rolls over to a new day. Resets in-memory stats, reloads from DB, and carries
-     * currently-pressing users into the new day as unique pressers and initial peak.
-     * Called both by the periodic timer and by [pressed] when a press detects a date change.
-     */
-    internal fun rollover() {
-        val newDay = LocalDate.now(clock)
-        val pressersAtRollover = currentlyPressing.toSet()
-        loadNewDay(newDay)
-
-        for (presser in pressersAtRollover) {
-            val presserId = presser.contact?.id?.toString() ?: presser.remoteHost
-            val isNew = uniquePresserIds.add(presserId)
-            if (isNew) {
-                dbOpChannel.trySend(NewPresser(newDay, presserId))
-            }
-        }
-        if (pressersAtRollover.isNotEmpty()) {
-            updatePeak(pressersAtRollover.size)
-        }
+    fun close() {
+        rolloverThreadPool.shutdown()
+        rolloverThreadPool.awaitTermination(5, TimeUnit.SECONDS)
+        dbOpChannel.close()
+        runBlocking { consumerJob.join() } // drain remaining ops before stopping the thread pool
+        dbThreadPool.shutdown()
     }
 
-    private fun checkRollover() {
-        val today = LocalDate.now(clock)
-        if (today != trackingDate) {
-            rollover()
-        }
-    }
-
-    private fun loadNewDay(date: LocalDate) {
-        dailyStatsDAO.ensureRow(date)
-        val row = dailyStatsDAO.findByDate(date)
-        uniquePresserIds.clear()
-        peakConcurrent.set(0)
-        totalPressCount.set(0)
-        if (row != null) {
-            peakConcurrent.set(row.peakConcurrent)
-            totalPressCount.set(row.totalPressCount)
-        }
-        uniquePresserIds.addAll(dailyPressersDAO.findByDate(date))
-        trackingDate = date
-    }
+    // --- Public API ---
 
     override suspend fun pressed(presser: Presser) {
         val today = LocalDate.now(clock)
@@ -176,25 +147,62 @@ class DailyStatsService @Inject constructor(
         currentlyPressing.remove(presser)
     }
 
-    private fun updatePeak(concurrentCount: Int) {
-        val prevPeak = peakConcurrent.getAndUpdate { max(it, concurrentCount) }
-        if (concurrentCount > prevPeak) {
-            dbOpChannel.trySend(NewPeak(trackingDate, concurrentCount))
-        }
-    }
-
     fun currentStats(): DailyStatsSnapshot = DailyStatsSnapshot(
         uniquePressers = uniquePresserIds.size,
         peakConcurrent = peakConcurrent.get(),
         totalPresses = totalPressCount.get(),
     )
 
-    fun close() {
-        rolloverThreadPool.shutdown()
-        rolloverThreadPool.awaitTermination(5, TimeUnit.SECONDS)
-        dbOpChannel.close()
-        runBlocking { consumerJob.join() } // drain remaining ops before stopping the thread pool
-        dbThreadPool.shutdown()
+    // --- Rollover implementation ---
+
+    private fun checkRollover() {
+        if (LocalDate.now(clock) != trackingDate) {
+            rollover()
+        }
+    }
+
+    /**
+     * Rolls over to a new day. Resets in-memory stats, reloads from DB, and carries
+     * currently-pressing users into the new day as unique pressers and initial peak.
+     * Called both by the periodic timer and by [pressed] when a press detects a date change.
+     */
+    internal fun rollover() {
+        val newDay = LocalDate.now(clock)
+        val pressersAtRollover = currentlyPressing.toSet()
+        loadNewDay(newDay)
+        for (presser in pressersAtRollover) {
+            val presserId = presser.contact?.id?.toString() ?: presser.remoteHost
+            val isNew = uniquePresserIds.add(presserId)
+            if (isNew) {
+                dbOpChannel.trySend(NewPresser(newDay, presserId))
+            }
+        }
+        if (pressersAtRollover.isNotEmpty()) {
+            updatePeak(pressersAtRollover.size)
+        }
+    }
+
+    private fun loadNewDay(date: LocalDate) {
+        dailyStatsDAO.ensureRow(date)
+        val row = dailyStatsDAO.findByDate(date)
+        uniquePresserIds.clear()
+        peakConcurrent.set(0)
+        totalPressCount.set(0)
+        if (row != null) {
+            peakConcurrent.set(row.peakConcurrent)
+            totalPressCount.set(row.totalPressCount)
+        }
+        uniquePresserIds.addAll(dailyPressersDAO.findByDate(date))
+        trackingDate = date
+    }
+
+    // --- DB write implementation ---
+
+    private fun updatePeak(concurrentCount: Int) {
+        val prevPeak = peakConcurrent.getAndUpdate { max(it, concurrentCount) }
+        if (concurrentCount > prevPeak) {
+            dbOpChannel.trySend(NewPeak(trackingDate, concurrentCount))
+        }
     }
 
     private fun processDbOp(op: DbOp) {

--- a/src/test/kotlin/sh/zachwal/button/presshistory/DailyStatsServiceTest.kt
+++ b/src/test/kotlin/sh/zachwal/button/presshistory/DailyStatsServiceTest.kt
@@ -22,6 +22,16 @@ import java.time.ZoneId
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
+// A Clock subclass whose date can be advanced in tests
+private class AdjustableClock(
+    @Volatile var date: LocalDate,
+    private val zone: ZoneId = ZoneId.systemDefault(),
+) : Clock() {
+    override fun getZone(): ZoneId = zone
+    override fun withZone(zone: ZoneId): Clock = AdjustableClock(date, zone)
+    override fun instant(): Instant = date.atStartOfDay(zone).toInstant()
+}
+
 @ExtendWith(DatabaseExtension::class)
 class DailyStatsServiceTest(private val jdbi: Jdbi) {
 
@@ -30,12 +40,18 @@ class DailyStatsServiceTest(private val jdbi: Jdbi) {
     private lateinit var service: DailyStatsService
 
     private val today = LocalDate.now()
+    private val adjustableClock = AdjustableClock(today)
 
     @BeforeEach
     fun setUp() {
         dailyStatsDAO = jdbi.onDemand()
         dailyPressersDAO = jdbi.onDemand()
-        service = DailyStatsService(dailyStatsDAO, dailyPressersDAO)
+        // Long rollover interval so the timer doesn't fire spontaneously in non-timer tests
+        service = DailyStatsService(
+            dailyStatsDAO,
+            dailyPressersDAO,
+            DailyStatsConfig(adjustableClock, rolloverCheckIntervalMs = 60_000L),
+        )
         service.initialize()
     }
 
@@ -44,11 +60,6 @@ class DailyStatsServiceTest(private val jdbi: Jdbi) {
         // Drain pending DB ops before DatabaseExtension truncates tables
         service.close()
     }
-
-    private val zone: ZoneId = ZoneId.systemDefault()
-
-    private fun clockFor(date: LocalDate): Clock =
-        Clock.fixed(date.atStartOfDay(zone).toInstant(), zone)
 
     private fun mockPresser(remoteHost: String = "127.0.0.1", contact: Contact? = null): Presser {
         return mockk<Presser>().also {
@@ -176,7 +187,7 @@ class DailyStatsServiceTest(private val jdbi: Jdbi) {
         assertThat(service.currentStats().totalPresses).isEqualTo(2)
         assertThat(service.currentStats().uniquePressers).isEqualTo(2)
 
-        service.clock = clockFor(today.plusDays(1))
+        adjustableClock.date = today.plusDays(1)
         service.pressed(mockPresser("9.10.11.12"))
 
         val stats = service.currentStats()
@@ -190,7 +201,7 @@ class DailyStatsServiceTest(private val jdbi: Jdbi) {
         val presserA = mockPresser("1.2.3.4")
         service.pressed(presserA) // pressing at end of day 1, never released
 
-        service.clock = clockFor(today.plusDays(1))
+        adjustableClock.date = today.plusDays(1)
         service.pressed(mockPresser("5.6.7.8")) // triggers rollover; A is still pressing
 
         // A + new presser = 2 concurrent
@@ -206,7 +217,7 @@ class DailyStatsServiceTest(private val jdbi: Jdbi) {
         dailyStatsDAO.updatePeakIfHigher(tomorrow, 7)
         dailyPressersDAO.insertIfAbsent(tomorrow, "existing-presser")
 
-        service.clock = clockFor(tomorrow)
+        adjustableClock.date = tomorrow
         service.pressed(mockPresser("new-host"))
 
         val stats = service.currentStats()
@@ -238,12 +249,98 @@ class DailyStatsServiceTest(private val jdbi: Jdbi) {
         dailyPressersDAO.insertIfAbsent(today, "presser-2")
 
         // New service instance simulates a process restart
-        val reloadedService = DailyStatsService(dailyStatsDAO, dailyPressersDAO)
+        val reloadedService = DailyStatsService(
+            dailyStatsDAO,
+            dailyPressersDAO,
+            DailyStatsConfig(Clock.systemDefaultZone(), rolloverCheckIntervalMs = 60_000L),
+        )
         reloadedService.initialize()
 
         val stats = reloadedService.currentStats()
         assertThat(stats.totalPresses).isEqualTo(3)
         assertThat(stats.peakConcurrent).isEqualTo(4)
         assertThat(stats.uniquePressers).isEqualTo(2)
+
+        reloadedService.close()
+    }
+
+    // ---- Timer-triggered rollover tests ----
+
+    private fun timerService(clock: AdjustableClock): DailyStatsService =
+        DailyStatsService(
+            dailyStatsDAO,
+            dailyPressersDAO,
+            DailyStatsConfig(clock, rolloverCheckIntervalMs = 50L),
+        ).also { it.initialize() }
+
+    @Test
+    fun `timer fires at midnight and resets stats - press and release before midnight zeroes everything`() {
+        service.close() // shut down the long-interval setUp service first
+
+        val timerClock = AdjustableClock(today)
+        val svc = timerService(timerClock)
+        try {
+            runBlocking {
+                val presser = mockPresser("1.2.3.4")
+                svc.pressed(presser)
+                svc.released(presser)
+            }
+            assertThat(svc.currentStats().totalPresses).isEqualTo(1)
+
+            timerClock.date = today.plusDays(1)
+            Thread.sleep(200) // let the 50ms timer fire
+
+            val stats = svc.currentStats()
+            assertThat(stats.totalPresses).isEqualTo(0)
+            assertThat(stats.uniquePressers).isEqualTo(0)
+            assertThat(stats.peakConcurrent).isEqualTo(0)
+        } finally {
+            svc.close()
+        }
+    }
+
+    @Test
+    fun `timer fires at midnight and current pressers carry over as unique pressers and peak`() {
+        service.close() // shut down the long-interval setUp service first
+
+        val timerClock = AdjustableClock(today)
+        val svc = timerService(timerClock)
+        try {
+            val presserA = mockPresser("1.2.3.4")
+            runBlocking { svc.pressed(presserA) } // press but never release
+
+            timerClock.date = today.plusDays(1)
+            Thread.sleep(200) // let the 50ms timer fire
+
+            val stats = svc.currentStats()
+            assertThat(stats.totalPresses).isEqualTo(0)
+            assertThat(stats.uniquePressers).isEqualTo(1)
+            assertThat(stats.peakConcurrent).isEqualTo(1)
+        } finally {
+            svc.close()
+        }
+    }
+
+    @Test
+    fun `timer rollover writes currently-pressing users to DB as new day pressers`() {
+        service.close()
+
+        val timerClock = AdjustableClock(today)
+        val svc = timerService(timerClock)
+        try {
+            val presserA = mockPresser("1.2.3.4")
+            runBlocking { svc.pressed(presserA) } // never released
+
+            timerClock.date = today.plusDays(1)
+            Thread.sleep(200)
+
+            svc.close() // drain DB ops
+
+            val tomorrow = today.plusDays(1)
+            val pressers = dailyPressersDAO.findByDate(tomorrow)
+            assertThat(pressers).contains("1.2.3.4")
+        } finally {
+            // svc already closed above; suppress double-close
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Adds `DailyStatsConfig` (holds `clock` and `rolloverCheckIntervalMs`) injected via `@Provides` in `ApplicationModule`, replacing the `internal var clock` hack
- Adds a `rollover()` method (separate from `initialize()`): snapshots `currentlyPressing` before resetting state, carries those users into the new day as unique pressers + initial peak, and writes them to the DB via `dbOpChannel`
- A dedicated `ScheduledExecutorService` (`daily-stats-rollover-*`) checks the clock every 500ms in production and calls `rollover()` if the date has changed — independent from the DB consumer pool so a slow DB write cannot delay the midnight check
- `pressed()` now calls `rollover()` instead of `initialize()` so press-triggered rollovers also carry over currently-pressing users correctly

## Test plan

- [x] All existing tests updated to use `AdjustableClock` (a `Clock` subclass with a mutable `date`) instead of `service.clock = ...`
- [x] `timer fires at midnight and resets stats - press and release before midnight zeroes everything` — timer fires, all stats zero
- [x] `timer fires at midnight and current pressers carry over as unique pressers and peak` — presser held across midnight counts as unique + peak on the new day
- [x] `timer rollover writes currently-pressing users to DB as new day pressers` — DB row written for carry-over presser
- [x] Full test suite passes (`./gradlew test`)
- [x] ktlint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)