### PR TITLE
Add nightly backup scripts for PostgreSQL DB

### DIFF
--- a/backup/README.md
+++ b/backup/README.md
@@ -1,0 +1,74 @@
+# Button Backup
+
+Daily PostgreSQL backups with a 7/4/6 retention policy (daily/weekly/monthly).
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `backup.sh` | Dumps the DB and manages retention cleanup |
+| `restore.sh` | Restores the DB from a dump file |
+| `button-backup.service` | Systemd oneshot service that runs `backup.sh` |
+| `button-backup.timer` | Systemd timer that fires nightly at 02:00 |
+
+## How backups work
+
+`backup.sh` runs `pg_dump --format=custom` and gzips the output to `~/backups/daily/button_YYYY-MM-DD.dump.gz`. It then conditionally copies that file to:
+
+- `~/backups/weekly/` — if today is Sunday
+- `~/backups/monthly/` — if today is the 1st of the month
+
+After copying, it prunes old files in each directory, keeping only the newest N:
+
+- **daily**: 7 files
+- **weekly**: 4 files
+- **monthly**: 6 files
+
+The DB name defaults to `button` but is read from the `$DB_NAME` environment variable if set (the service unit loads `/home/button/button.env` which sets this in production).
+
+## Installation
+
+Because `button` is not a sudoer, installation is split: `button` owns everything under `~/backup/`, but a sudoer must install the systemd units.
+
+### 1. Deploy the scripts (as `button`)
+
+```bash
+mkdir -p ~/backup ~/backups
+cp backup.sh restore.sh ~/backup/
+chmod +x ~/backup/backup.sh ~/backup/restore.sh
+```
+
+### 2. Install the systemd units (as a sudoer)
+
+```bash
+sudo cp button-backup.service button-backup.timer /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now button-backup.timer
+```
+
+Verify the timer is scheduled:
+
+```bash
+systemctl list-timers button-backup.timer
+```
+
+### 3. Verify with a manual run (as `button`)
+
+```bash
+systemctl start button-backup.service   # requires sudo, or ask a sudoer
+# or run the script directly:
+~/backup/backup.sh
+ls ~/backups/daily/
+```
+
+## Restoring
+
+Pass any `.dump.gz` file from any of the three backup directories:
+
+```bash
+~/backup/restore.sh ~/backups/daily/button_2026-04-26.dump.gz
+```
+
+The script drops all existing objects in the DB and restores from the dump. It does **not** drop or recreate the database itself, so no superuser privileges are needed.
+
+> **Note:** `--no-owner` is passed to `pg_restore`, so restored objects will be owned by whichever role runs the restore. In production this is `button`, which is correct.

--- a/backup/backup.sh
+++ b/backup/backup.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DB_NAME="${DB_NAME:-button}"
+BACKUP_ROOT="${HOME}/backups"
+DATE=$(date +%Y-%m-%d)
+DOW=$(date +%u)   # 1=Mon … 7=Sun
+DOM=$(date +%d)   # day of month, zero-padded
+
+DAILY_DIR="${BACKUP_ROOT}/daily"
+WEEKLY_DIR="${BACKUP_ROOT}/weekly"
+MONTHLY_DIR="${BACKUP_ROOT}/monthly"
+
+mkdir -p "$DAILY_DIR" "$WEEKLY_DIR" "$MONTHLY_DIR"
+
+DUMP_FILE="${DAILY_DIR}/button_${DATE}.dump.gz"
+
+pg_dump --format=custom "$DB_NAME" | gzip > "$DUMP_FILE"
+
+# Weekly: keep Sundays (DOW == 7)
+if [ "$DOW" -eq 7 ]; then
+    cp "$DUMP_FILE" "${WEEKLY_DIR}/button_${DATE}.dump.gz"
+fi
+
+# Monthly: keep 1st of month
+if [ "$DOM" -eq "01" ]; then
+    cp "$DUMP_FILE" "${MONTHLY_DIR}/button_${DATE}.dump.gz"
+fi
+
+# Retention cleanup
+find "$DAILY_DIR"   -name "button_*.dump.gz" | sort | head -n -7  | xargs -r rm --
+find "$WEEKLY_DIR"  -name "button_*.dump.gz" | sort | head -n -4  | xargs -r rm --
+find "$MONTHLY_DIR" -name "button_*.dump.gz" | sort | head -n -6  | xargs -r rm --

--- a/backup/button-backup.service
+++ b/backup/button-backup.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Button database backup
+After=network.target postgresql.service
+
+[Service]
+Type=oneshot
+User=button
+EnvironmentFile=/home/button/button.env
+ExecStart=/home/button/backup/backup.sh

--- a/backup/button-backup.timer
+++ b/backup/button-backup.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run button-backup.service nightly at 02:00
+
+[Timer]
+OnCalendar=*-*-* 02:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/backup/restore.sh
+++ b/backup/restore.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DB_NAME="${DB_NAME:-button}"
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <backup_file.dump.gz>" >&2
+    exit 1
+fi
+
+BACKUP_FILE="$1"
+
+if [ ! -f "$BACKUP_FILE" ]; then
+    echo "Error: file not found: $BACKUP_FILE" >&2
+    exit 1
+fi
+
+echo "Restoring $DB_NAME from $BACKUP_FILE ..."
+
+# Drop all objects in the DB then restore — avoids needing to drop/recreate the DB itself.
+gunzip -c "$BACKUP_FILE" | pg_restore --dbname="$DB_NAME" --clean --if-exists --no-owner --no-privileges
+
+echo "Done."


### PR DESCRIPTION
## Summary

- `backup.sh`: pg_dumps the `button` DB nightly, gzips to `~/backups/daily/`. Copies to `weekly/` on Sundays and `monthly/` on the 1st. Prunes old files to retain 7 daily, 4 weekly, 6 monthly.
- `restore.sh`: restores from any `.dump.gz` file using `pg_restore --clean --if-exists --no-owner`.
- `button-backup.service` / `button-backup.timer`: systemd units that fire at 02:00 nightly as the `button` user.
- `README.md`: usage and installation instructions, including the split install process for servers where `button` is not a sudoer.

## Test plan

- [x] Ran `backup.sh` locally — dump created at `~/backups/daily/button_2026-04-26.dump.gz`
- [x] Truncated `press` table, ran `restore.sh`, confirmed all 3,738 rows restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)