### PR TITLE
Add admin contact press stats page

### DIFF
--- a/docs/contact-press-stats-plan.md
+++ b/docs/contact-press-stats-plan.md
@@ -29,18 +29,18 @@ entirely. If it starts before today, both sources are queried and merged by `con
 
 ### New files
 
-| File | Purpose |
-|------|---------|
-| `src/main/kotlin/sh/zachwal/button/admin/ContactPressStatsService.kt` | Hybrid query logic |
-| `src/main/kotlin/sh/zachwal/button/admin/ContactPressStatsController.kt` | Route + HTML rendering |
-| `src/test/kotlin/sh/zachwal/button/admin/ContactPressStatsServiceTest.kt` | Unit tests (MockK) |
+| File                                                                      | Purpose                |
+|---------------------------------------------------------------------------|------------------------|
+| `src/main/kotlin/sh/zachwal/button/admin/ContactPressStatsService.kt`     | Hybrid query logic     |
+| `src/main/kotlin/sh/zachwal/button/admin/ContactPressStatsController.kt`  | Route + HTML rendering |
+| `src/test/kotlin/sh/zachwal/button/admin/ContactPressStatsServiceTest.kt` | Unit tests (MockK)     |
 
 ### Modified files
 
-| File | Change |
-|------|--------|
-| `src/main/kotlin/sh/zachwal/button/db/dao/PressDAO.kt` | Add `countByContactSince` |
-| `src/test/kotlin/sh/zachwal/button/db/dao/PressDAOTest.kt` | Test for new DAO method |
+| File                                                         | Change                       |
+|--------------------------------------------------------------|------------------------------|
+| `src/main/kotlin/sh/zachwal/button/db/dao/PressDAO.kt`       | Add `countByContactSince`    |
+| `src/test/kotlin/sh/zachwal/button/db/dao/PressDAOTest.kt`   | Test for new DAO method      |
 | `src/main/kotlin/sh/zachwal/button/admin/AdminController.kt` | Add link under Stats section |
 
 ---
@@ -101,11 +101,11 @@ class ContactPressStatsService @Inject constructor(
     fun pressStats(range: TimeRange): List<ContactPressStat> {
         val today = LocalDate.now(ZoneOffset.UTC)
         val startDate: LocalDate = when (range) {
-            TimeRange.TODAY        -> today
-            TimeRange.LAST_7_DAYS  -> today.minusDays(7)
+            TimeRange.TODAY -> today
+            TimeRange.LAST_7_DAYS -> today.minusDays(7)
             TimeRange.LAST_30_DAYS -> today.minusDays(30)
             TimeRange.YEAR_TO_DATE -> LocalDate.of(today.year, 1, 1)
-            TimeRange.ALL_TIME     -> LocalDate.ofEpochDay(0)
+            TimeRange.ALL_TIME -> LocalDate.ofEpochDay(0)
         }
 
         // Materialized counts (startDate..yesterday)
@@ -157,12 +157,12 @@ Unit tests (use MockK, no real DB):
 - Extract `range` query parameter (default `30d`)
 - Call `service.pressStats(range)`
 - Render page with `respondHtml`:
-  - `headSetup()` + Bootstrap 4
-  - `h1` "Contact Press Stats"
-  - `form(method = FormMethod.get)` with a `select` dropdown for time range and a
-    "Go" submit button; selected option reflects current range
-  - `responsiveTable` with columns: **Name**, **Presses**; one row per `ContactPressStat`
-  
+    - `headSetup()` + Bootstrap 4
+    - `h1` "Contact Press Stats"
+    - `form(method = FormMethod.get)` with a `select` dropdown for time range and a
+      "Go" submit button; selected option reflects current range
+    - `responsiveTable` with columns: **Name**, **Presses**; one row per `ContactPressStat`
+
 Pattern reference: `AdminStatsController.kt` and `AdminContactController.kt`.
 
 **Admin link** — in `AdminController.kt`, inside the Stats `ul` block, add:
@@ -184,9 +184,11 @@ pattern — no manual registration needed, just the `@Controller` annotation).
 
 The implementing agent **must pause and ask the user for feedback before each commit**.
 
-### Commit 1 — DAO layer  
+### Commit 1 — DAO layer
+
 **Files**: `PressDAO.kt`, `PressDAOTest.kt`  
 **TDD steps**:
+
 1. Write failing test for `countByContactSince` in `PressDAOTest`
 2. Run `./gradlew test --tests PressDAOTest` → expect failure
 3. Add method to `PressDAO`
@@ -194,9 +196,11 @@ The implementing agent **must pause and ask the user for feedback before each co
 5. **Pause. Ask user to review the DAO change before committing.**
 6. Commit: `Add countByContactSince to PressDAO`
 
-### Commit 2 — Service layer  
+### Commit 2 — Service layer
+
 **Files**: `ContactPressStatsService.kt`, `ContactPressStatsServiceTest.kt`  
 **TDD steps**:
+
 1. Write failing unit tests for `ContactPressStatsService`
 2. Run tests → expect failure
 3. Implement service and `TimeRange` enum
@@ -204,15 +208,18 @@ The implementing agent **must pause and ask the user for feedback before each co
 5. **Pause. Ask user to review the service before committing.**
 6. Commit: `Add ContactPressStatsService with hybrid materialized/live query`
 
-### Commit 3 — Controller and UI  
+### Commit 3 — Controller and UI
+
 **Files**: `ContactPressStatsController.kt`, `AdminController.kt`  
 **Steps**:
+
 1. Implement controller and add admin index link
 2. Run `./gradlew build` → expect green
 3. **Pause. Ask user to run the app and review the page UI before committing.**
 4. Commit: `Add admin contact press stats page`
 
-### Final step — Push branch and open PR  
+### Final step — Push branch and open PR
+
 After user approves all commits, push the branch and open a GitHub PR against `main`.
 Use `gh pr create` with a descriptive title and summary body.
 

--- a/docs/contact-press-stats-plan.md
+++ b/docs/contact-press-stats-plan.md
@@ -1,0 +1,233 @@
+# Plan: Admin Contact Press Stats Page
+
+## Goal
+
+Add a new admin page at `/admin/contact-press-stats` that shows each contact's press
+count for a user-selected time range. The page lives in the existing admin Stats section.
+
+## UX Requirements
+
+- **Time ranges** (dropdown): Today, Last 7 Days, Last 30 Days, Year to Date, All Time
+- **Table**: Contact name + press count; only contacts with ≥1 press in range shown
+- **Sort**: Count descending
+- **Default range**: Last 30 Days
+
+## Architecture
+
+### Data strategy
+
+All press data up to (and including) yesterday UTC is materialized into the
+`contact_press_counts` table by `ContactPressCountMaterializationTask`. Today's data
+is only in the raw `press` table. The service combines both sources:
+
+```
+total = materialized (startDate..yesterday) + live press table (today midnight..now)
+```
+
+If the selected range starts today (i.e., "Today"), the materialized query is skipped
+entirely. If it starts before today, both sources are queried and merged by `contactId`.
+
+### New files
+
+| File | Purpose |
+|------|---------|
+| `src/main/kotlin/sh/zachwal/button/admin/ContactPressStatsService.kt` | Hybrid query logic |
+| `src/main/kotlin/sh/zachwal/button/admin/ContactPressStatsController.kt` | Route + HTML rendering |
+| `src/test/kotlin/sh/zachwal/button/admin/ContactPressStatsServiceTest.kt` | Unit tests (MockK) |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `src/main/kotlin/sh/zachwal/button/db/dao/PressDAO.kt` | Add `countByContactSince` |
+| `src/test/kotlin/sh/zachwal/button/db/dao/PressDAOTest.kt` | Test for new DAO method |
+| `src/main/kotlin/sh/zachwal/button/admin/AdminController.kt` | Add link under Stats section |
+
+---
+
+## Implementation detail
+
+### Step 1 — New PressDAO method
+
+Add to `PressDAO`:
+
+```kotlin
+@KeyColumn("contact_id")
+@ValueColumn("count")
+@SqlQuery(
+    """
+    select contact_id, count(*) as count
+    from press
+    where time >= :since and contact_id is not null
+    group by contact_id
+    """
+)
+fun countByContactSince(since: Instant): Map<Int, Long>
+```
+
+DAO test (`PressDAOTest`): create two contacts, insert presses at various times, assert that
+`countByContactSince` returns correct per-contact totals and excludes anonymous presses
+(`contact_id IS NULL`).
+
+### Step 2 — TimeRange enum and ContactPressStatsService
+
+Declare `TimeRange` inside or alongside the service (or in a dedicated small file in the
+`admin` package):
+
+```kotlin
+enum class TimeRange(val label: String, val queryParam: String) {
+    TODAY("Today", "today"),
+    LAST_7_DAYS("Last 7 Days", "7d"),
+    LAST_30_DAYS("Last 30 Days", "30d"),
+    YEAR_TO_DATE("Year to Date", "ytd"),
+    ALL_TIME("All Time", "all");
+
+    companion object {
+        fun fromParam(param: String?): TimeRange =
+            values().find { it.queryParam == param } ?: LAST_30_DAYS
+    }
+}
+```
+
+Service logic outline:
+
+```kotlin
+@Singleton
+class ContactPressStatsService @Inject constructor(
+    private val contactDAO: ContactDAO,
+    private val contactPressCountDAO: ContactPressCountDAO,
+    private val pressDAO: PressDAO,
+) {
+    fun pressStats(range: TimeRange): List<ContactPressStat> {
+        val today = LocalDate.now(ZoneOffset.UTC)
+        val startDate: LocalDate = when (range) {
+            TimeRange.TODAY        -> today
+            TimeRange.LAST_7_DAYS  -> today.minusDays(7)
+            TimeRange.LAST_30_DAYS -> today.minusDays(30)
+            TimeRange.YEAR_TO_DATE -> LocalDate.of(today.year, 1, 1)
+            TimeRange.ALL_TIME     -> LocalDate.ofEpochDay(0)
+        }
+
+        // Materialized counts (startDate..yesterday)
+        val yesterday = today.minusDays(1)
+        val materialized: Map<Int, Long> = if (startDate <= yesterday) {
+            contactPressCountDAO
+                .aggregateCountsByContact(startDate, yesterday)
+                .mapValues { it.value.toLong() }
+        } else {
+            emptyMap()
+        }
+
+        // Today's raw counts
+        val todayStart = today.atStartOfDay(ZoneOffset.UTC).toInstant()
+        val todayCounts: Map<Int, Long> = pressDAO.countByContactSince(todayStart)
+
+        // Merge
+        val allIds = (materialized.keys + todayCounts.keys).toSet()
+        val contactsById = contactDAO.selectContacts().associateBy { it.id }
+
+        return allIds.mapNotNull { id ->
+            val contact = contactsById[id] ?: return@mapNotNull null
+            val count = (materialized[id] ?: 0L) + (todayCounts[id] ?: 0L)
+            ContactPressStat(contact, count)
+        }
+            .filter { it.count > 0 }
+            .sortedByDescending { it.count }
+    }
+}
+
+data class ContactPressStat(val contact: Contact, val count: Long)
+```
+
+Unit tests (use MockK, no real DB):
+
+- `pressStats TODAY returns only live press counts` — mock materialized returning empty
+  (or verify it's not called), mock `countByContactSince` with data
+- `pressStats LAST_7_DAYS merges materialized and today counts correctly` — mock both
+  sources with overlapping contact IDs, assert totals are summed
+- `pressStats excludes contacts with zero count` — ensure a contact in the contacts list
+  with nothing in either map doesn't appear
+- `pressStats falls back to LAST_30_DAYS for unknown query param` — test
+  `TimeRange.fromParam`
+
+### Step 3 — Controller and admin link
+
+**Controller** at `/admin/contact-press-stats`:
+
+- Extract `range` query parameter (default `30d`)
+- Call `service.pressStats(range)`
+- Render page with `respondHtml`:
+  - `headSetup()` + Bootstrap 4
+  - `h1` "Contact Press Stats"
+  - `form(method = FormMethod.get)` with a `select` dropdown for time range and a
+    "Go" submit button; selected option reflects current range
+  - `responsiveTable` with columns: **Name**, **Presses**; one row per `ContactPressStat`
+  
+Pattern reference: `AdminStatsController.kt` and `AdminContactController.kt`.
+
+**Admin link** — in `AdminController.kt`, inside the Stats `ul` block, add:
+
+```kotlin
+li {
+    a(href = "/admin/contact-press-stats") {
+        +"Contact Press Stats"
+    }
+}
+```
+
+Register the new controller in Guice (follow the existing `@Controller` + `ControllerCreator`
+pattern — no manual registration needed, just the `@Controller` annotation).
+
+---
+
+## Commit / checkpoint sequence
+
+The implementing agent **must pause and ask the user for feedback before each commit**.
+
+### Commit 1 — DAO layer  
+**Files**: `PressDAO.kt`, `PressDAOTest.kt`  
+**TDD steps**:
+1. Write failing test for `countByContactSince` in `PressDAOTest`
+2. Run `./gradlew test --tests PressDAOTest` → expect failure
+3. Add method to `PressDAO`
+4. Run tests → expect green
+5. **Pause. Ask user to review the DAO change before committing.**
+6. Commit: `Add countByContactSince to PressDAO`
+
+### Commit 2 — Service layer  
+**Files**: `ContactPressStatsService.kt`, `ContactPressStatsServiceTest.kt`  
+**TDD steps**:
+1. Write failing unit tests for `ContactPressStatsService`
+2. Run tests → expect failure
+3. Implement service and `TimeRange` enum
+4. Run tests → expect green
+5. **Pause. Ask user to review the service before committing.**
+6. Commit: `Add ContactPressStatsService with hybrid materialized/live query`
+
+### Commit 3 — Controller and UI  
+**Files**: `ContactPressStatsController.kt`, `AdminController.kt`  
+**Steps**:
+1. Implement controller and add admin index link
+2. Run `./gradlew build` → expect green
+3. **Pause. Ask user to run the app and review the page UI before committing.**
+4. Commit: `Add admin contact press stats page`
+
+### Final step — Push branch and open PR  
+After user approves all commits, push the branch and open a GitHub PR against `main`.
+Use `gh pr create` with a descriptive title and summary body.
+
+---
+
+## Notes for the implementing agent
+
+- Use `ZoneOffset.UTC` for all date calculations (consistent with the rest of the codebase).
+- Do not add error handling for impossible cases (e.g., unknown contact IDs in press data);
+  `mapNotNull` naturally handles FK mismatches.
+- The `@Controller` annotation + `ControllerCreator` auto-discovery means no manual Guice
+  binding is needed for the new controller — just ensure the class has `@Controller` and is
+  in a package scanned by the application module.
+- Check `JdbiModule.kt` to confirm `ContactPressCountDAO` is already bound (it is, per
+  exploration); no new Guice binding is needed for DAOs.
+- The service should be `@Singleton` (stateless but injected).
+- Keep HTML generation consistent with existing admin pages: `headSetup()`,
+  `responsiveTable()`, Bootstrap 4 classes.

--- a/src/main/kotlin/sh/zachwal/button/admin/AdminController.kt
+++ b/src/main/kotlin/sh/zachwal/button/admin/AdminController.kt
@@ -133,6 +133,11 @@ class AdminController @Inject constructor(
                                         +"Recent Presses"
                                     }
                                 }
+                                li {
+                                    a(href = "/admin/contact-press-stats") {
+                                        +"Contact Press Stats"
+                                    }
+                                }
                             }
                             h2 {
                                 +"Config"

--- a/src/main/kotlin/sh/zachwal/button/admin/ContactPressStatsController.kt
+++ b/src/main/kotlin/sh/zachwal/button/admin/ContactPressStatsController.kt
@@ -1,0 +1,82 @@
+package sh.zachwal.button.admin
+
+import com.google.inject.Inject
+import io.ktor.server.application.call
+import io.ktor.server.html.respondHtml
+import io.ktor.server.routing.Routing
+import io.ktor.server.routing.get
+import kotlinx.html.FormMethod
+import kotlinx.html.body
+import kotlinx.html.div
+import kotlinx.html.form
+import kotlinx.html.h1
+import kotlinx.html.head
+import kotlinx.html.option
+import kotlinx.html.select
+import kotlinx.html.submitInput
+import kotlinx.html.tbody
+import kotlinx.html.td
+import kotlinx.html.th
+import kotlinx.html.thead
+import kotlinx.html.title
+import kotlinx.html.tr
+import sh.zachwal.button.controller.Controller
+import sh.zachwal.button.roles.adminRoute
+import sh.zachwal.button.sharedhtml.headSetup
+import sh.zachwal.button.sharedhtml.responsiveTable
+
+@Controller
+class ContactPressStatsController @Inject constructor(
+    private val service: ContactPressStatsService,
+) {
+
+    internal fun Routing.contactPressStats() {
+        adminRoute("/admin/contact-press-stats") {
+            get {
+                val range = TimeRange.fromParam(call.request.queryParameters["range"])
+                val stats = service.pressStats(range)
+
+                call.respondHtml {
+                    head {
+                        title { +"Contact Press Stats" }
+                        headSetup()
+                    }
+                    body {
+                        div(classes = "container") {
+                            h1(classes = "mt-4 text-center") { +"Contact Press Stats" }
+                            form(classes = "d-flex align-items-center my-3 px-2", method = FormMethod.get) {
+                                select(classes = "form-control flex-grow-1 mr-2") {
+                                    name = "range"
+                                    TimeRange.entries.forEach { tr ->
+                                        option {
+                                            value = tr.queryParam
+                                            selected = tr == range
+                                            +tr.label
+                                        }
+                                    }
+                                }
+                                submitInput(classes = "btn btn-primary") { value = "Go" }
+                            }
+                            responsiveTable(classes = "mt-3") {
+                                thead {
+                                    tr {
+                                        th { +"Name" }
+                                        th { +"Presses" }
+                                    }
+                                }
+                                tbody {
+                                    stats.forEach { stat ->
+                                        tr {
+                                            td { +stat.contact.name }
+                                            td { +stat.count.toString() }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/sh/zachwal/button/admin/ContactPressStatsService.kt
+++ b/src/main/kotlin/sh/zachwal/button/admin/ContactPressStatsService.kt
@@ -1,0 +1,66 @@
+package sh.zachwal.button.admin
+
+import sh.zachwal.button.db.dao.ContactDAO
+import sh.zachwal.button.db.dao.ContactPressCountDAO
+import sh.zachwal.button.db.dao.PressDAO
+import sh.zachwal.button.db.jdbi.Contact
+import java.time.LocalDate
+import java.time.ZoneOffset
+import javax.inject.Inject
+import javax.inject.Singleton
+
+enum class TimeRange(val label: String, val queryParam: String) {
+    TODAY("Today", "today"),
+    LAST_7_DAYS("Last 7 Days", "7d"),
+    LAST_30_DAYS("Last 30 Days", "30d"),
+    YEAR_TO_DATE("Year to Date", "ytd"),
+    ALL_TIME("All Time", "all");
+
+    companion object {
+        fun fromParam(param: String?): TimeRange =
+            entries.find { it.queryParam == param } ?: LAST_30_DAYS
+    }
+}
+
+data class ContactPressStat(val contact: Contact, val count: Long)
+
+@Singleton
+class ContactPressStatsService @Inject constructor(
+    private val contactDAO: ContactDAO,
+    private val contactPressCountDAO: ContactPressCountDAO,
+    private val pressDAO: PressDAO,
+) {
+    fun pressStats(range: TimeRange): List<ContactPressStat> {
+        val today = LocalDate.now(ZoneOffset.UTC)
+        val startDate: LocalDate = when (range) {
+            TimeRange.TODAY -> today
+            TimeRange.LAST_7_DAYS -> today.minusDays(7)
+            TimeRange.LAST_30_DAYS -> today.minusDays(30)
+            TimeRange.YEAR_TO_DATE -> LocalDate.of(today.year, 1, 1)
+            TimeRange.ALL_TIME -> LocalDate.ofEpochDay(0)
+        }
+
+        val yesterday = today.minusDays(1)
+        val materialized: Map<Int, Long> = if (startDate <= yesterday) {
+            contactPressCountDAO
+                .aggregateCountsByContact(startDate, yesterday)
+                .mapValues { it.value.toLong() }
+        } else {
+            emptyMap()
+        }
+
+        val todayStart = today.atStartOfDay(ZoneOffset.UTC).toInstant()
+        val todayCounts: Map<Int, Long> = pressDAO.countByContactSince(todayStart)
+
+        val allIds = (materialized.keys + todayCounts.keys).toSet()
+        val contactsById = contactDAO.selectContacts().associateBy { it.id }
+
+        return allIds.mapNotNull { id ->
+            val contact = contactsById[id] ?: return@mapNotNull null
+            val count = (materialized[id] ?: 0L) + (todayCounts[id] ?: 0L)
+            ContactPressStat(contact, count)
+        }
+            .filter { it.count > 0 }
+            .sortedByDescending { it.count }
+    }
+}

--- a/src/main/kotlin/sh/zachwal/button/db/dao/PressDAO.kt
+++ b/src/main/kotlin/sh/zachwal/button/db/dao/PressDAO.kt
@@ -78,4 +78,16 @@ interface PressDAO {
         startDate: LocalDate,
         endDate: LocalDate
     ): Map<LocalDate, Int>
+
+    @KeyColumn("contact_id")
+    @ValueColumn("count")
+    @SqlQuery(
+        """
+        select contact_id, count(*) as count
+        from press
+        where time >= :since and contact_id is not null
+        group by contact_id
+        """
+    )
+    fun countByContactSince(since: Instant): Map<Int, Long>
 }

--- a/src/test/kotlin/sh/zachwal/button/admin/ContactPressStatsServiceIntegrationTest.kt
+++ b/src/test/kotlin/sh/zachwal/button/admin/ContactPressStatsServiceIntegrationTest.kt
@@ -78,7 +78,7 @@ class ContactPressStatsServiceIntegrationTest(private val jdbi: Jdbi) {
         val byName = result.associateBy { it.contact.name }
 
         assertThat(byName["Alice"]!!.count).isEqualTo(14) // 5+7+2
-        assertThat(byName["Bob"]!!.count).isEqualTo(13)   // 8+5
+        assertThat(byName["Bob"]!!.count).isEqualTo(13) // 8+5
         assertThat(result.map { it.count }).isInOrder(Comparator.reverseOrder<Long>())
         assertThat(byName.keys).doesNotContain("Carol")
     }

--- a/src/test/kotlin/sh/zachwal/button/admin/ContactPressStatsServiceIntegrationTest.kt
+++ b/src/test/kotlin/sh/zachwal/button/admin/ContactPressStatsServiceIntegrationTest.kt
@@ -1,0 +1,104 @@
+package sh.zachwal.button.admin
+
+import com.google.common.truth.Truth.assertThat
+import org.jdbi.v3.core.Jdbi
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import sh.zachwal.button.db.dao.ContactDAO
+import sh.zachwal.button.db.dao.ContactPressCountDAO
+import sh.zachwal.button.db.dao.PressDAO
+import sh.zachwal.button.db.extension.DatabaseExtension
+import sh.zachwal.button.db.jdbi.Contact
+import sh.zachwal.button.db.jdbi.ContactPressCount
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+@ExtendWith(DatabaseExtension::class)
+class ContactPressStatsServiceIntegrationTest(private val jdbi: Jdbi) {
+
+    private lateinit var service: ContactPressStatsService
+
+    private lateinit var alice: Contact
+    private lateinit var bob: Contact
+    private lateinit var carol: Contact
+
+    private val today = LocalDate.now(ZoneOffset.UTC)
+
+    @BeforeEach
+    fun setup() {
+        val contactDAO = jdbi.onDemand(ContactDAO::class.java)
+        val contactPressCountDAO = jdbi.onDemand(ContactPressCountDAO::class.java)
+        val pressDAO = jdbi.onDemand(PressDAO::class.java)
+
+        service = ContactPressStatsService(contactDAO, contactPressCountDAO, pressDAO)
+
+        alice = contactDAO.createContact("Alice", "+15550000001")
+        bob = contactDAO.createContact("Bob", "+15550000002")
+        carol = contactDAO.createContact("Carol", "+15550000003") // no presses — always excluded
+
+        // Materialized counts within last 30 days
+        // Alice: day -15: 5, day -5: 7 → 12 materialized in last 30d
+        contactPressCountDAO.upsert(ContactPressCount(alice.id, today.minusDays(15), 5))
+        contactPressCountDAO.upsert(ContactPressCount(alice.id, today.minusDays(5), 7))
+        // Alice: older than 30 days (only visible in ALL_TIME)
+        contactPressCountDAO.upsert(ContactPressCount(alice.id, today.minusDays(60), 20))
+        // Bob: day -10 — inside last 30d but outside last 7d
+        contactPressCountDAO.upsert(ContactPressCount(bob.id, today.minusDays(10), 8))
+
+        // Live presses today: Alice 2, Bob 5
+        repeat(2) { pressDAO.createPress("127.0.0.1", alice.id) }
+        repeat(5) { pressDAO.createPress("127.0.0.1", bob.id) }
+    }
+
+    @Test
+    fun `TODAY returns only live press counts from the press table`() {
+        val result = service.pressStats(TimeRange.TODAY)
+        val byName = result.associateBy { it.contact.name }
+
+        assertThat(byName["Alice"]!!.count).isEqualTo(2)
+        assertThat(byName["Bob"]!!.count).isEqualTo(5)
+        assertThat(byName.keys).doesNotContain("Carol")
+    }
+
+    @Test
+    fun `LAST_7_DAYS excludes materialized rows older than 7 days`() {
+        val result = service.pressStats(TimeRange.LAST_7_DAYS)
+        val byName = result.associateBy { it.contact.name }
+
+        // Alice: day -5 (7) + 2 today = 9; day -15 excluded
+        assertThat(byName["Alice"]!!.count).isEqualTo(9)
+        // Bob: day -10 excluded; only 5 today
+        assertThat(byName["Bob"]!!.count).isEqualTo(5)
+    }
+
+    @Test
+    fun `LAST_30_DAYS merges materialized and live counts and sorts descending`() {
+        val result = service.pressStats(TimeRange.LAST_30_DAYS)
+        val byName = result.associateBy { it.contact.name }
+
+        assertThat(byName["Alice"]!!.count).isEqualTo(14) // 5+7+2
+        assertThat(byName["Bob"]!!.count).isEqualTo(13)   // 8+5
+        assertThat(result.map { it.count }).isInOrder(Comparator.reverseOrder<Long>())
+        assertThat(byName.keys).doesNotContain("Carol")
+    }
+
+    @Test
+    fun `ALL_TIME includes materialized rows older than 30 days`() {
+        val result = service.pressStats(TimeRange.ALL_TIME)
+        val byName = result.associateBy { it.contact.name }
+
+        // Alice: 5+7+20 materialized + 2 today = 34
+        assertThat(byName["Alice"]!!.count).isEqualTo(34)
+        // Bob: no old presses, same as LAST_30_DAYS
+        assertThat(byName["Bob"]!!.count).isEqualTo(13)
+    }
+
+    @Test
+    fun `contacts with no presses are excluded from all ranges`() {
+        for (range in TimeRange.values()) {
+            val names = service.pressStats(range).map { it.contact.name }
+            assertThat(names).doesNotContain("Carol")
+        }
+    }
+}

--- a/src/test/kotlin/sh/zachwal/button/admin/ContactPressStatsServiceTest.kt
+++ b/src/test/kotlin/sh/zachwal/button/admin/ContactPressStatsServiceTest.kt
@@ -1,0 +1,261 @@
+package sh.zachwal.button.admin
+
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import sh.zachwal.button.db.dao.ContactDAO
+import sh.zachwal.button.db.dao.ContactPressCountDAO
+import sh.zachwal.button.db.dao.PressDAO
+import sh.zachwal.button.db.jdbi.Contact
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+class ContactPressStatsServiceTest {
+
+    private val contactDAO = mockk<ContactDAO>()
+    private val contactPressCountDAO = mockk<ContactPressCountDAO>()
+    private val pressDAO = mockk<PressDAO>()
+
+    private val service = ContactPressStatsService(contactDAO, contactPressCountDAO, pressDAO)
+
+    private val today = LocalDate.now(ZoneOffset.UTC)
+    private val yesterday = today.minusDays(1)
+    private val todayMidnight = today.atStartOfDay(ZoneOffset.UTC).toInstant()
+
+    private fun contact(id: Int, name: String) = Contact(
+        id = id,
+        createdDate = Instant.EPOCH,
+        name = name,
+        phoneNumber = "+15550000000",
+        active = true,
+    )
+
+    // --- TODAY range ---
+
+    @Test
+    fun `pressStats TODAY skips materialized query entirely`() {
+        every { contactDAO.selectContacts() } returns emptyList()
+        every { pressDAO.countByContactSince(any()) } returns emptyMap()
+
+        service.pressStats(TimeRange.TODAY)
+
+        verify(exactly = 0) { contactPressCountDAO.aggregateCountsByContact(any(), any()) }
+    }
+
+    @Test
+    fun `pressStats TODAY passes today midnight UTC to countByContactSince`() {
+        val sinceSlot = slot<Instant>()
+        every { contactDAO.selectContacts() } returns emptyList()
+        every { pressDAO.countByContactSince(capture(sinceSlot)) } returns emptyMap()
+
+        service.pressStats(TimeRange.TODAY)
+
+        assertThat(sinceSlot.captured).isEqualTo(todayMidnight)
+    }
+
+    // --- Materialized query date ranges ---
+
+    @Test
+    fun `pressStats LAST_7_DAYS queries materialized from 7 days ago through yesterday`() {
+        val startSlot = slot<LocalDate>()
+        val endSlot = slot<LocalDate>()
+        every { contactDAO.selectContacts() } returns emptyList()
+        every { contactPressCountDAO.aggregateCountsByContact(capture(startSlot), capture(endSlot)) } returns emptyMap()
+        every { pressDAO.countByContactSince(any()) } returns emptyMap()
+
+        service.pressStats(TimeRange.LAST_7_DAYS)
+
+        assertThat(startSlot.captured).isEqualTo(today.minusDays(7))
+        assertThat(endSlot.captured).isEqualTo(yesterday)
+    }
+
+    @Test
+    fun `pressStats LAST_30_DAYS queries materialized from 30 days ago through yesterday`() {
+        val startSlot = slot<LocalDate>()
+        val endSlot = slot<LocalDate>()
+        every { contactDAO.selectContacts() } returns emptyList()
+        every { contactPressCountDAO.aggregateCountsByContact(capture(startSlot), capture(endSlot)) } returns emptyMap()
+        every { pressDAO.countByContactSince(any()) } returns emptyMap()
+
+        service.pressStats(TimeRange.LAST_30_DAYS)
+
+        assertThat(startSlot.captured).isEqualTo(today.minusDays(30))
+        assertThat(endSlot.captured).isEqualTo(yesterday)
+    }
+
+    @Test
+    fun `pressStats YEAR_TO_DATE queries materialized from Jan 1 of current year through yesterday`() {
+        val startSlot = slot<LocalDate>()
+        val endSlot = slot<LocalDate>()
+        every { contactDAO.selectContacts() } returns emptyList()
+        every { contactPressCountDAO.aggregateCountsByContact(capture(startSlot), capture(endSlot)) } returns emptyMap()
+        every { pressDAO.countByContactSince(any()) } returns emptyMap()
+
+        service.pressStats(TimeRange.YEAR_TO_DATE)
+
+        assertThat(startSlot.captured).isEqualTo(LocalDate.of(today.year, 1, 1))
+        assertThat(endSlot.captured).isEqualTo(yesterday)
+    }
+
+    @Test
+    fun `pressStats ALL_TIME queries materialized from epoch day zero through yesterday`() {
+        val startSlot = slot<LocalDate>()
+        val endSlot = slot<LocalDate>()
+        every { contactDAO.selectContacts() } returns emptyList()
+        every { contactPressCountDAO.aggregateCountsByContact(capture(startSlot), capture(endSlot)) } returns emptyMap()
+        every { pressDAO.countByContactSince(any()) } returns emptyMap()
+
+        service.pressStats(TimeRange.ALL_TIME)
+
+        assertThat(startSlot.captured).isEqualTo(LocalDate.ofEpochDay(0))
+        assertThat(endSlot.captured).isEqualTo(yesterday)
+    }
+
+    @Test
+    fun `pressStats non-TODAY ranges always pass today midnight UTC to countByContactSince`() {
+        val sinceSlot = slot<Instant>()
+        every { contactDAO.selectContacts() } returns emptyList()
+        every { contactPressCountDAO.aggregateCountsByContact(any(), any()) } returns emptyMap()
+        every { pressDAO.countByContactSince(capture(sinceSlot)) } returns emptyMap()
+
+        service.pressStats(TimeRange.LAST_7_DAYS)
+
+        assertThat(sinceSlot.captured).isEqualTo(todayMidnight)
+    }
+
+    // --- Merge logic ---
+
+    @Test
+    fun `pressStats sums materialized and today counts for the same contact`() {
+        val alice = contact(1, "Alice")
+        every { contactDAO.selectContacts() } returns listOf(alice)
+        every { contactPressCountDAO.aggregateCountsByContact(any(), any()) } returns mapOf(1 to 10)
+        every { pressDAO.countByContactSince(any()) } returns mapOf(1 to 3L)
+
+        val result = service.pressStats(TimeRange.LAST_7_DAYS)
+
+        assertThat(result).hasSize(1)
+        assertThat(result[0].count).isEqualTo(13L)
+    }
+
+    @Test
+    fun `pressStats contact with only materialized count appears with correct total`() {
+        val alice = contact(1, "Alice")
+        every { contactDAO.selectContacts() } returns listOf(alice)
+        every { contactPressCountDAO.aggregateCountsByContact(any(), any()) } returns mapOf(1 to 7)
+        every { pressDAO.countByContactSince(any()) } returns emptyMap()
+
+        val result = service.pressStats(TimeRange.LAST_30_DAYS)
+
+        assertThat(result).hasSize(1)
+        assertThat(result[0].count).isEqualTo(7L)
+    }
+
+    @Test
+    fun `pressStats contact with only today count appears with correct total`() {
+        val alice = contact(1, "Alice")
+        every { contactDAO.selectContacts() } returns listOf(alice)
+        every { contactPressCountDAO.aggregateCountsByContact(any(), any()) } returns emptyMap()
+        every { pressDAO.countByContactSince(any()) } returns mapOf(1 to 4L)
+
+        val result = service.pressStats(TimeRange.LAST_30_DAYS)
+
+        assertThat(result).hasSize(1)
+        assertThat(result[0].count).isEqualTo(4L)
+    }
+
+    @Test
+    fun `pressStats multiple contacts with overlapping data merge correctly`() {
+        val alice = contact(1, "Alice")
+        val bob = contact(2, "Bob")
+        every { contactDAO.selectContacts() } returns listOf(alice, bob)
+        every { contactPressCountDAO.aggregateCountsByContact(any(), any()) } returns mapOf(1 to 10, 2 to 3)
+        every { pressDAO.countByContactSince(any()) } returns mapOf(1 to 2L)
+
+        val result = service.pressStats(TimeRange.LAST_7_DAYS)
+
+        val byId = result.associateBy { it.contact.id }
+        assertThat(byId[1]!!.count).isEqualTo(12L)
+        assertThat(byId[2]!!.count).isEqualTo(3L)
+    }
+
+    // --- Filtering ---
+
+    @Test
+    fun `pressStats excludes contacts with zero total count`() {
+        val alice = contact(1, "Alice")
+        val bob = contact(2, "Bob")
+        every { contactDAO.selectContacts() } returns listOf(alice, bob)
+        every { contactPressCountDAO.aggregateCountsByContact(any(), any()) } returns mapOf(1 to 5)
+        every { pressDAO.countByContactSince(any()) } returns emptyMap()
+
+        val result = service.pressStats(TimeRange.LAST_30_DAYS)
+
+        assertThat(result).hasSize(1)
+        assertThat(result[0].contact).isEqualTo(alice)
+    }
+
+    @Test
+    fun `pressStats excludes contact IDs in press data that are absent from contactDAO`() {
+        val alice = contact(1, "Alice")
+        every { contactDAO.selectContacts() } returns listOf(alice)
+        // Contact ID 99 appears in press data but not in contactDAO (FK mismatch)
+        every { contactPressCountDAO.aggregateCountsByContact(any(), any()) } returns mapOf(1 to 3, 99 to 10)
+        every { pressDAO.countByContactSince(any()) } returns emptyMap()
+
+        val result = service.pressStats(TimeRange.LAST_30_DAYS)
+
+        assertThat(result).hasSize(1)
+        assertThat(result[0].contact).isEqualTo(alice)
+    }
+
+    @Test
+    fun `pressStats returns empty list when no presses in range`() {
+        every { contactDAO.selectContacts() } returns listOf(contact(1, "Alice"))
+        every { contactPressCountDAO.aggregateCountsByContact(any(), any()) } returns emptyMap()
+        every { pressDAO.countByContactSince(any()) } returns emptyMap()
+
+        val result = service.pressStats(TimeRange.LAST_30_DAYS)
+
+        assertThat(result).isEmpty()
+    }
+
+    // --- Sort order ---
+
+    @Test
+    fun `pressStats result is sorted by count descending`() {
+        val alice = contact(1, "Alice")
+        val bob = contact(2, "Bob")
+        val carol = contact(3, "Carol")
+        every { contactDAO.selectContacts() } returns listOf(alice, bob, carol)
+        every { contactPressCountDAO.aggregateCountsByContact(any(), any()) } returns mapOf(1 to 2, 2 to 10, 3 to 5)
+        every { pressDAO.countByContactSince(any()) } returns emptyMap()
+
+        val result = service.pressStats(TimeRange.LAST_30_DAYS)
+
+        assertThat(result.map { it.contact }).containsExactly(bob, carol, alice).inOrder()
+        assertThat(result.map { it.count }).containsExactly(10L, 5L, 2L).inOrder()
+    }
+
+    // --- TimeRange.fromParam ---
+
+    @Test
+    fun `TimeRange fromParam falls back to LAST_30_DAYS for null, empty, and unknown params`() {
+        assertThat(TimeRange.fromParam(null)).isEqualTo(TimeRange.LAST_30_DAYS)
+        assertThat(TimeRange.fromParam("")).isEqualTo(TimeRange.LAST_30_DAYS)
+        assertThat(TimeRange.fromParam("bogus")).isEqualTo(TimeRange.LAST_30_DAYS)
+    }
+
+    @Test
+    fun `TimeRange fromParam resolves all known query params`() {
+        assertThat(TimeRange.fromParam("today")).isEqualTo(TimeRange.TODAY)
+        assertThat(TimeRange.fromParam("7d")).isEqualTo(TimeRange.LAST_7_DAYS)
+        assertThat(TimeRange.fromParam("30d")).isEqualTo(TimeRange.LAST_30_DAYS)
+        assertThat(TimeRange.fromParam("ytd")).isEqualTo(TimeRange.YEAR_TO_DATE)
+        assertThat(TimeRange.fromParam("all")).isEqualTo(TimeRange.ALL_TIME)
+    }
+}

--- a/src/test/kotlin/sh/zachwal/button/db/dao/PressDAOTest.kt
+++ b/src/test/kotlin/sh/zachwal/button/db/dao/PressDAOTest.kt
@@ -49,4 +49,34 @@ class PressDAOTest(private val jdbi: Jdbi) {
         assertEquals(1, counts[yesterday])
         assertEquals(null, counts[today])
     }
+
+    @Test
+    fun `countByContactSince returns correct per-contact totals`() {
+        val alice = contactDAO.createContact("Alice", "+15550000003")
+        val bob = contactDAO.createContact("Bob", "+15550000004")
+        val since = Instant.now().minus(1, ChronoUnit.HOURS)
+        // Alice: 3 presses after since, 1 before
+        pressDAO.createPressAtTime("remote", alice.id, since.minus(10, ChronoUnit.MINUTES))
+        pressDAO.createPressAtTime("remote", alice.id, since.plus(1, ChronoUnit.MINUTES))
+        pressDAO.createPressAtTime("remote", alice.id, since.plus(2, ChronoUnit.MINUTES))
+        pressDAO.createPressAtTime("remote", alice.id, since.plus(3, ChronoUnit.MINUTES))
+        // Bob: 1 press after since
+        pressDAO.createPressAtTime("remote", bob.id, since.plus(5, ChronoUnit.MINUTES))
+
+        val counts = pressDAO.countByContactSince(since)
+
+        assertEquals(3L, counts[alice.id])
+        assertEquals(1L, counts[bob.id])
+    }
+
+    @Test
+    fun `countByContactSince excludes anonymous presses`() {
+        val since = Instant.now().minus(1, ChronoUnit.HOURS)
+        // Anonymous press (contact_id is null)
+        pressDAO.createPressAtTime("remote", null, since.plus(1, ChronoUnit.MINUTES))
+
+        val counts = pressDAO.countByContactSince(since)
+
+        assertThat(counts).isEmpty()
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `/admin/contact-press-stats` page showing per-contact press counts for a user-selected time range (Today, Last 7 Days, Last 30 Days, Year to Date, All Time)
- Combines materialized `contact_press_counts` data (up through yesterday) with live `press` table data (today) for accurate counts across all ranges
- Results sorted by count descending; contacts with zero presses in range excluded

## Implementation

- `PressDAO.countByContactSince` — new DAO method querying live press counts grouped by contact
- `ContactPressStatsService` — hybrid query service merging materialized and live sources
- `ContactPressStatsController` — GET `/admin/contact-press-stats` with dropdown time range selector
- Link added to the Stats section of the admin index

## Test plan

- [ ] Unit tests for `ContactPressStatsService` covering date ranges per enum value, merge logic, filtering, and sort order
- [ ] Integration tests against a real DB via `DatabaseExtension` covering TODAY, LAST_7_DAYS, LAST_30_DAYS, ALL_TIME, and zero-count exclusion
- [ ] Integration tests for `PressDAO.countByContactSince` covering per-contact totals and anonymous press exclusion
- [ ] Visit `/admin/contact-press-stats` and verify the page loads, dropdown changes the results, and the table is sorted correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)