### PR TITLE
Add leaderboard page for contacts

### DIFF
--- a/frontend/src/main/css/leaderboard.css
+++ b/frontend/src/main/css/leaderboard.css
@@ -1,0 +1,3 @@
+@view-transition {
+    navigation: auto;
+}

--- a/frontend/src/main/js/leaderboard.js
+++ b/frontend/src/main/js/leaderboard.js
@@ -1,0 +1,12 @@
+document.addEventListener('DOMContentLoaded', function () {
+    const select = document.querySelector('select[name="range"]');
+    const indicator = document.getElementById('stale-indicator');
+
+    select.addEventListener('change', function () {
+        indicator.style.display = '';
+    });
+
+    document.querySelector('form').addEventListener('submit', function () {
+        indicator.style.display = 'none';
+    });
+});

--- a/src/main/kotlin/sh/zachwal/button/admin/ContactPressStatsController.kt
+++ b/src/main/kotlin/sh/zachwal/button/admin/ContactPressStatsController.kt
@@ -20,8 +20,10 @@ import kotlinx.html.th
 import kotlinx.html.thead
 import kotlinx.html.title
 import kotlinx.html.tr
+import kotlinx.html.HTML
 import sh.zachwal.button.controller.Controller
 import sh.zachwal.button.roles.adminRoute
+import sh.zachwal.button.roles.contactRoute
 import sh.zachwal.button.sharedhtml.headSetup
 import sh.zachwal.button.sharedhtml.responsiveTable
 
@@ -35,43 +37,51 @@ class ContactPressStatsController @Inject constructor(
             get {
                 val range = TimeRange.fromParam(call.request.queryParameters["range"])
                 val stats = service.pressStats(range)
+                call.respondHtml { leaderboardPage(range, stats) }
+            }
+        }
+        contactRoute("/leaderboard") {
+            get {
+                val range = TimeRange.fromParam(call.request.queryParameters["range"])
+                val stats = service.pressStats(range)
+                call.respondHtml { leaderboardPage(range, stats) }
+            }
+        }
+    }
 
-                call.respondHtml {
-                    head {
-                        title { +"Contact Press Stats" }
-                        headSetup()
-                    }
-                    body {
-                        div(classes = "container") {
-                            h1(classes = "mt-4 text-center") { +"Contact Press Stats" }
-                            form(classes = "d-flex align-items-center my-3 px-2", method = FormMethod.get) {
-                                select(classes = "form-control flex-grow-1 mr-2") {
-                                    name = "range"
-                                    TimeRange.entries.forEach { tr ->
-                                        option {
-                                            value = tr.queryParam
-                                            selected = tr == range
-                                            +tr.label
-                                        }
-                                    }
-                                }
-                                submitInput(classes = "btn btn-primary") { value = "Go" }
+    private fun HTML.leaderboardPage(range: TimeRange, stats: List<ContactPressStat>) {
+        head {
+            title { +"Leaderboard" }
+            headSetup()
+        }
+        body {
+            div(classes = "container") {
+                h1(classes = "mt-4 text-center") { +"Leaderboard" }
+                form(classes = "d-flex align-items-center my-3 px-2", method = FormMethod.get) {
+                    select(classes = "form-control flex-grow-1 mr-2") {
+                        name = "range"
+                        TimeRange.entries.forEach { tr ->
+                            option {
+                                value = tr.queryParam
+                                selected = tr == range
+                                +tr.label
                             }
-                            responsiveTable(classes = "mt-3") {
-                                thead {
-                                    tr {
-                                        th { +"Name" }
-                                        th { +"Presses" }
-                                    }
-                                }
-                                tbody {
-                                    stats.forEach { stat ->
-                                        tr {
-                                            td { +stat.contact.name }
-                                            td { +stat.count.toString() }
-                                        }
-                                    }
-                                }
+                        }
+                    }
+                    submitInput(classes = "btn btn-primary") { value = "Go" }
+                }
+                responsiveTable(classes = "mt-3") {
+                    thead {
+                        tr {
+                            th { +"Name" }
+                            th { +"Presses" }
+                        }
+                    }
+                    tbody {
+                        stats.forEach { stat ->
+                            tr {
+                                td { +stat.contact.name }
+                                td { +stat.count.toString() }
                             }
                         }
                     }

--- a/src/main/kotlin/sh/zachwal/button/admin/ContactPressStatsController.kt
+++ b/src/main/kotlin/sh/zachwal/button/admin/ContactPressStatsController.kt
@@ -6,13 +6,17 @@ import io.ktor.server.html.respondHtml
 import io.ktor.server.routing.Routing
 import io.ktor.server.routing.get
 import kotlinx.html.FormMethod
+import kotlinx.html.HTML
 import kotlinx.html.body
 import kotlinx.html.div
 import kotlinx.html.form
 import kotlinx.html.h1
 import kotlinx.html.head
+import kotlinx.html.link
 import kotlinx.html.option
+import kotlinx.html.script
 import kotlinx.html.select
+import kotlinx.html.span
 import kotlinx.html.submitInput
 import kotlinx.html.tbody
 import kotlinx.html.td
@@ -20,7 +24,6 @@ import kotlinx.html.th
 import kotlinx.html.thead
 import kotlinx.html.title
 import kotlinx.html.tr
-import kotlinx.html.HTML
 import sh.zachwal.button.controller.Controller
 import sh.zachwal.button.roles.adminRoute
 import sh.zachwal.button.roles.contactRoute
@@ -53,22 +56,32 @@ class ContactPressStatsController @Inject constructor(
         head {
             title { +"Leaderboard" }
             headSetup()
+            link(rel = "stylesheet", href = "/static/src/css/leaderboard.css", type = "text/css")
         }
         body {
             div(classes = "container") {
                 h1(classes = "mt-4 text-center") { +"Leaderboard" }
-                form(classes = "d-flex align-items-center my-3 px-2", method = FormMethod.get) {
-                    select(classes = "form-control flex-grow-1 mr-2") {
-                        name = "range"
-                        TimeRange.entries.forEach { tr ->
-                            option {
-                                value = tr.queryParam
-                                selected = tr == range
-                                +tr.label
+                form(classes = "my-3 px-2", method = FormMethod.get) {
+                    div(classes = "d-flex align-items-center") {
+                        select(classes = "form-control flex-grow-1 mr-2") {
+                            name = "range"
+                            TimeRange.entries.forEach { tr ->
+                                option {
+                                    value = tr.queryParam
+                                    selected = tr == range
+                                    +tr.label
+                                }
                             }
                         }
+                        submitInput(classes = "btn btn-primary") { value = "Go" }
                     }
-                    submitInput(classes = "btn btn-primary") { value = "Go" }
+                    div(classes = "text-center mt-1") {
+                        span(classes = "text-muted small") {
+                            attributes["id"] = "stale-indicator"
+                            attributes["style"] = "display:none"
+                            +"Hit Go to refresh"
+                        }
+                    }
                 }
                 responsiveTable(classes = "mt-3") {
                     thead {
@@ -80,6 +93,7 @@ class ContactPressStatsController @Inject constructor(
                     tbody {
                         stats.forEach { stat ->
                             tr {
+                                attributes["style"] = "view-transition-name: contact-${stat.contact.id}"
                                 td { +stat.contact.name }
                                 td { +stat.count.toString() }
                             }
@@ -87,6 +101,7 @@ class ContactPressStatsController @Inject constructor(
                     }
                 }
             }
+            script { src = "/static/src/js/leaderboard.js" }
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds `/leaderboard` route accessible to any authenticated contact (via `contactRoute()`), showing press counts ranked by time range
- Keeps existing `/admin/contact-press-stats` route for admins; both routes share the same rendered page
- Adds cross-document View Transitions: each row gets a `view-transition-name` keyed to the contact ID, so rows animate to their new positions when the ranking changes between time ranges
- Adds a stale indicator (gray, centered below the picker) that appears when the time range is changed before hitting Go

## Test plan

- [ ] Visit `/leaderboard` as an authenticated contact — page loads and shows ranked press counts
- [ ] Visit `/admin/contact-press-stats` as admin — still works as before
- [ ] Change the time range picker without hitting Go — "Hit Go to refresh" appears in gray below the controls
- [ ] Hit Go — stale indicator disappears and rows reorder with a smooth View Transition animation
- [ ] Unauthenticated visit to `/leaderboard` redirects to `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)