### PR TITLE
Fix flaky timer rollover tests in DailyStatsServiceTest

### DIFF
--- a/src/main/kotlin/sh/zachwal/button/presshistory/DailyStatsService.kt
+++ b/src/main/kotlin/sh/zachwal/button/presshistory/DailyStatsService.kt
@@ -147,6 +147,7 @@ class DailyStatsService @Inject constructor(
         currentlyPressing.remove(presser)
     }
 
+    @Synchronized
     fun currentStats(): DailyStatsSnapshot = DailyStatsSnapshot(
         uniquePressers = uniquePresserIds.size,
         peakConcurrent = peakConcurrent.get(),
@@ -165,9 +166,13 @@ class DailyStatsService @Inject constructor(
      * Rolls over to a new day. Resets in-memory stats, reloads from DB, and carries
      * currently-pressing users into the new day as unique pressers and initial peak.
      * Called both by the periodic timer and by [pressed] when a press detects a date change.
+     * Synchronized to prevent concurrent rollovers and to make currentStats() reads atomic
+     * with respect to the clear-then-reload sequence in loadNewDay.
      */
+    @Synchronized
     internal fun rollover() {
         val newDay = LocalDate.now(clock)
+        if (newDay == trackingDate) return // already rolled over by another caller
         val pressersAtRollover = currentlyPressing.toSet()
         loadNewDay(newDay)
         for (presser in pressersAtRollover) {

--- a/src/test/kotlin/sh/zachwal/button/presshistory/DailyStatsServiceTest.kt
+++ b/src/test/kotlin/sh/zachwal/button/presshistory/DailyStatsServiceTest.kt
@@ -288,7 +288,12 @@ class DailyStatsServiceTest(private val jdbi: Jdbi) {
             assertThat(svc.currentStats().totalPresses).isEqualTo(1)
 
             timerClock.date = today.plusDays(1)
-            Thread.sleep(200) // let the 50ms timer fire
+            // Poll until the timer fires and rollover resets totalPresses to 0.
+            // Avoids a fixed sleep that races with the 50ms timer on loaded CI machines.
+            val deadline = System.currentTimeMillis() + 5_000L
+            while (svc.currentStats().totalPresses > 0 && System.currentTimeMillis() < deadline) {
+                Thread.sleep(10)
+            }
 
             val stats = svc.currentStats()
             assertThat(stats.totalPresses).isEqualTo(0)
@@ -310,7 +315,12 @@ class DailyStatsServiceTest(private val jdbi: Jdbi) {
             runBlocking { svc.pressed(presserA) } // press but never release
 
             timerClock.date = today.plusDays(1)
-            Thread.sleep(200) // let the 50ms timer fire
+            // Poll until the timer fires and rollover resets totalPresses to 0.
+            // Avoids a fixed sleep that races with the 50ms timer on loaded CI machines.
+            val deadline = System.currentTimeMillis() + 5_000L
+            while (svc.currentStats().totalPresses > 0 && System.currentTimeMillis() < deadline) {
+                Thread.sleep(10)
+            }
 
             val stats = svc.currentStats()
             assertThat(stats.totalPresses).isEqualTo(0)


### PR DESCRIPTION
## Summary

Two concurrent races caused intermittent failures for the midnight-rollover timer tests on loaded CI runs.

**Race A — read before timer fires**: `Thread.sleep(200)` could expire before the 50ms timer fired, leaving the test reading pre-rollover state. Fixed by replacing the fixed sleep with a polling loop (`totalPresses > 0`) that exits as soon as rollover has reset the new day's press count to 0.

**Race B — read during rollover**: `currentStats()` could land between `uniquePresserIds.clear()` (start of `loadNewDay`) and the re-addition of `pressersAtRollover` (end of `rollover()`), returning a transient 0 for `uniquePressers`. Fixed by adding `@Synchronized` to both `rollover()` and `currentStats()` so a read always sees a complete before- or after-rollover snapshot. The guard `if (newDay == trackingDate) return` at the top of `rollover()` prevents a second concurrent caller from re-running a rollover that already completed.

## Test plan

- [x] `./gradlew test --tests "sh.zachwal.button.presshistory.DailyStatsServiceTest"` passes
- [x] `./gradlew test` (full suite) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)