### PR TITLE
Decouple deployment from Jenkins: server-side CD via systemd timers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,11 +62,13 @@ npm --prefix frontend test            # Run tests
 
 ## Deployment & CI/CD
 
-- **CI/CD Pipeline**: Jenkinsfile orchestrates build, test, lint, and deployment
-- **Environments**: Test environment for pre-production validation; production deployment on merges to main
-- **Migrations**: Liquibase migrations run automatically via CI/CD pipeline
-- **Runtime Config**: Systemd units read environment variables from `EnvironmentFile` (e.g., `/home/{button|testbutton}/button.env`) containing `DB_USER`, `DB_PASSWORD`, `DB_NAME`
-- **Distribution**: `./gradlew assemble` creates `build/distributions/button.tar`; unpacked and run via `button/bin/button`
+- **CI**: Jenkinsfile runs build, lint, and test, then sets a GitHub commit status (`continuous-integration/jenkins`)
+- **CD**: Server-side `scripts/deploy.sh`, triggered by systemd timers (`button-deploy.timer`, `testbutton-deploy.timer`), polls for a new green commit and deploys it
+- **Environments**: `button` (production) deploys `origin/main`; `testbutton` deploys the tip of the most-recently-updated remote branch
+- **Migrations**: `db/migrate.sh` (Liquibase) is run by `deploy.sh` on each deploy
+- **Runtime Config**: Systemd units read environment variables from `EnvironmentFile` (`~/button.env`) containing `DB_USER`, `DB_PASSWORD`, `DB_NAME`, etc.
+- **Distribution**: `./gradlew assemble` creates `build/distributions/button.tar`; unpacked into `~/releases/$SHA/` and symlinked to `~/releases/current`
+- **Credentials**: Deploy key at `~/.ssh/deploy_key` for git access; fine-grained PAT at `~/.github_token` for reading CI status
 
 ## Coding Patterns
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,67 +37,6 @@ pipeline {
                 }
             }
         }
-        stage('test-release') {
-            steps {
-                // Clear testbutton releases
-                sh "rm -rf ~testbutton/releases/*"
-                // Create the release
-                sh "mkdir -p ~testbutton/releases/$GIT_COMMIT"
-                sh "tar -xvf build/distributions/button.tar -C ~testbutton/releases/$GIT_COMMIT"
-                // Set it as current
-                sh "ln -s ~testbutton/releases/$GIT_COMMIT ~testbutton/releases/current"
-                // Restart the button service (only has sudo permissions for this command)
-                sh "sudo systemctl restart testbutton"
-            }
-        }
-        stage('migrate database - testbutton') {
-            when {
-                expression { env.GIT_BRANCH == 'origin/main' }
-            }
-            steps {
-                // Copy migrations & script into ~testbutton
-                sh "rm -rf ~testbutton/migrations/*"
-                sh "cp -r db ~testbutton/migrations"
-
-                // Run migrations as testbutton
-                dir("/home/testbutton/migrations/db") {
-                    sh "sudo -u testbutton ./migrate.sh"
-                }
-            }
-        }
-        stage('migrate database - button') {
-            when {
-                expression { env.GIT_BRANCH == 'origin/main' }
-            }
-            steps {
-                // Copy migrations & script into ~testbutton
-                sh "rm -rf ~button/migrations/*"
-                sh "cp -r db ~button/migrations"
-
-                // Run migrations as testbutton
-                dir("/home/button/migrations/db") {
-                    sh "sudo -u button ./migrate.sh"
-                }
-            }
-        }
-        stage('release') {
-            when {
-                expression { env.GIT_BRANCH == 'origin/main' }
-            }
-            steps {
-                // Delete all but the three most recent releases
-                sh "ls -t ~button/releases | tail -n +4 | xargs -I {} rm -rf ~button/releases/{}"
-
-                // Create the release
-                sh "mkdir -p ~button/releases/$GIT_COMMIT"
-                sh "tar -xvf build/distributions/button.tar -C ~button/releases/$GIT_COMMIT"
-                // Set it as current
-                sh "rm -f ~button/releases/current"
-                sh "ln -s ~button/releases/$GIT_COMMIT ~button/releases/current"
-                // Restart the button service (only has sudo permissions for this command)
-                sh "sudo systemctl restart button"
-            }
-        }
     }
     post {
         success {

--- a/docs/cd-migration-plan.md
+++ b/docs/cd-migration-plan.md
@@ -1,0 +1,227 @@
+# CD Migration Plan: Decouple Deployment from Jenkins
+
+## Goal
+
+Allow Jenkins to run CI (build, lint, test) on ephemeral Swarm agents that are not colocated
+with the production server. Deployment is handled by scripts running on the server itself,
+triggered by systemd timers, using a GitHub Deploy Key for `git` access and a fine-grained
+GitHub PAT for reading CI status.
+
+## Architecture
+
+**Before**: Jenkins agent (must be colocated) → builds tarball → copies files into `~button/` →
+runs migrations → restarts systemd unit.
+
+**After**: Jenkins agent (ephemeral, anywhere) → builds, lints, tests → sets GitHub commit
+status. Meanwhile, a systemd timer on the server (running as the service user) polls for a new
+green commit on the target branch, pulls source, builds locally, migrates, and restarts.
+
+```
+Jenkins (any agent)          Production server
+──────────────────           ──────────────────────────────────────────────
+assemble                     [timer fires every 5 min]
+ktlintCheck                  deploy.sh
+gradle check         ──────▶   git fetch (via deploy key)
+frontend test        status    check GitHub status API (via fine-grained PAT)
+setBuildStatus ◀────────────   git checkout $SHA
+                               ./gradlew assemble
+                               unpack into ~/releases/$SHA/
+                               db/migrate.sh
+                               ln -sfn ~/releases/$SHA ~/releases/current
+                               sudo systemctl restart button
+                               echo $SHA > ~/deployed_commit
+```
+
+## Credentials
+
+Two separate credentials are needed on the server, owned by the service user:
+
+| Credential       | Type            | Purpose                            | Location on server            |
+|------------------|-----------------|------------------------------------|-------------------------------|
+| Deploy Key       | SSH private key | `git fetch` from GitHub            | `~/.ssh/button_deploy_key`    |
+| Fine-grained PAT | HTTP token      | Read commit status from GitHub API | `~/.github_token` (chmod 600) |
+
+The fine-grained PAT should be scoped to the `zwalsh/button` repository, with only
+**"Commit statuses: Read-only"** permission, and no expiration.
+
+The deploy key is read-only (no push access needed).
+
+Both credentials are needed on **both** `button` and `testbutton` users (they can share the same
+keypair and token or use separate ones).
+
+## Branch Targeting
+
+- **`button`** (production): deploys the latest commit on `origin/main` only.
+- **`testbutton`** (test): deploys the tip of whichever remote branch was most recently updated.
+
+Both wait for the target commit's CI status to be `success` before deploying.
+
+## Files Changed
+
+### `Jenkinsfile`
+
+Remove the `test-release`, `migrate database - testbutton`, `migrate database - button`, and
+`release` stages entirely. Jenkins becomes pure CI: `start`, `assemble`, `lint`, `test`, and
+`post` (test results + commit status). No deploy logic remains.
+
+### `docs/deploy.md`
+
+Update to describe the new CD mechanism: deploy key setup, systemd timer, deploy script
+behavior, and the `~/deployed_commit` sentinel file.
+
+### `CLAUDE.md`
+
+Update the **Deployment & CI/CD** section to reflect that Jenkins only runs CI, and that
+deployment is driven by the server-side deploy scripts and systemd timers.
+
+## Files Added
+
+### `scripts/deploy.sh`
+
+Parameterized deploy script. Called by both systemd services. Accepts `--env button` or
+`--env testbutton` to control which branch to target and which service to restart. Logic:
+
+1. `git -C ~/src fetch origin`
+2. Resolve target SHA:
+    - `button`: `git rev-parse origin/main`
+    - `testbutton`: tip of most-recently-updated remote branch (`git for-each-ref
+     --sort=-committerdate`)
+3. Read `~/deployed_commit`; exit 0 if already deployed
+4. Query `https://api.github.com/repos/zwalsh/button/commits/$SHA/statuses`; exit 0 if not
+   `success`
+5. `git -C ~/src checkout $SHA`
+6. `~/src/gradlew assemble` → produces `~/src/build/distributions/button.tar`
+7. `mkdir -p ~/releases/$SHA && tar -xf ... -C ~/releases/$SHA`
+8. Run `~/src/db/migrate.sh` (unchanged; reads credentials from `~/button.env` via `find ~`)
+9. `ln -sfn ~/releases/$SHA ~/releases/current`
+10. `sudo systemctl restart button` (or `testbutton`)
+11. `echo $SHA > ~/deployed_commit`
+12. Prune `~/releases/`: keep the 3 most recent, delete the rest
+
+### `scripts/button-deploy.service`
+
+Systemd service unit that runs `deploy.sh --env button` as the `button` user.
+
+### `scripts/button-deploy.timer`
+
+Systemd timer unit that triggers `button-deploy.service` every 5 minutes.
+
+### `scripts/testbutton-deploy.service`
+
+Systemd service unit that runs `deploy.sh --env testbutton` as the `testbutton` user.
+
+### `scripts/testbutton-deploy.timer`
+
+Systemd timer unit that triggers `testbutton-deploy.service` every 5 minutes.
+
+## Dependencies on the Server
+
+The following must be present for the service users on the production host:
+
+- **JDK 17** (confirmed present)
+- **Gradle wrapper** (`./gradlew` in the repo checkout — downloads Gradle automatically)
+- **Liquibase** on `$PATH` (currently used by `migrate.sh`; confirm it is available to
+  `button`/`testbutton` users, not just the Jenkins user)
+- **`jq`** (for parsing the GitHub API JSON response)
+- **`git`** on `$PATH`
+
+## Manual Steps (One-Time Server Setup)
+
+These cannot be scripted from this repo and must be done by hand:
+
+### 1. Generate the deploy key
+
+```bash
+ssh-keygen -t ed25519 -f ~/.ssh/button_deploy_key -C "button-deploy" -N ""
+```
+
+Run this once; the same keypair can be placed under both `button` and `testbutton` users.
+
+### 2. Register the public key on GitHub
+
+In `https://github.com/zwalsh/button` → Settings → Deploy keys → Add deploy key.
+Paste the contents of `~/.ssh/button_deploy_key.pub`. Select **read-only** (no write access).
+
+### 3. Create the fine-grained PAT
+
+In GitHub → Settings → Developer Settings → Fine-grained tokens → Generate new token:
+
+- Resource owner: `zwalsh`
+- Repository access: only `zwalsh/button`
+- Permissions → Repository permissions → Commit statuses: **Read-only**
+- Expiration: **No expiration**
+
+### 4. Set up credentials on the server (repeat for both users)
+
+As `button` (and separately as `testbutton`):
+
+```bash
+# Deploy key
+mkdir -p ~/.ssh
+# Copy private key content to ~/.ssh/button_deploy_key
+chmod 600 ~/.ssh/button_deploy_key
+
+# SSH config so git uses the deploy key for github.com
+cat >> ~/.ssh/config <<'EOF'
+Host github.com
+    IdentityFile ~/.ssh/button_deploy_key
+    IdentitiesOnly yes
+EOF
+chmod 600 ~/.ssh/config
+
+# GitHub token
+echo "ghp_xxxxxxxxxxxxxxxxxxxx" > ~/.github_token
+chmod 600 ~/.github_token
+```
+
+### 5. Clone the repo on the server (repeat for both users)
+
+```bash
+git clone git@github.com:zwalsh/button.git ~/src
+```
+
+### 6. Update sudoers
+
+The service users need permission to restart their own systemd unit. Add (via `visudo` or a
+file in `/etc/sudoers.d/`):
+
+```
+button     ALL=(ALL) NOPASSWD: /bin/systemctl restart button
+testbutton ALL=(ALL) NOPASSWD: /bin/systemctl restart testbutton
+```
+
+The existing Jenkins sudo rules for these restarts (and for `sudo -u button/testbutton`) can
+be removed once the new scripts are confirmed working.
+
+### 7. Install and enable the systemd timers
+
+```bash
+sudo cp scripts/button-deploy.service    /etc/systemd/system/
+sudo cp scripts/button-deploy.timer      /etc/systemd/system/
+sudo cp scripts/testbutton-deploy.service /etc/systemd/system/
+sudo cp scripts/testbutton-deploy.timer   /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now button-deploy.timer
+sudo systemctl enable --now testbutton-deploy.timer
+```
+
+### 8. Seed the deployed_commit file
+
+To prevent the first timer firing from re-deploying the currently running version
+unnecessarily, seed the sentinel with the SHA that is currently live:
+
+```bash
+# as button:
+readlink ~/releases/current | xargs basename > ~/deployed_commit
+# as testbutton:
+readlink ~/releases/current | xargs basename > ~/deployed_commit
+```
+
+## Rollout Order
+
+1. Implement and merge Jenkinsfile changes (CI-only) — Jenkins stops deploying.
+2. Implement `scripts/deploy.sh` and the four systemd unit files.
+3. Update `docs/deploy.md` and `CLAUDE.md`.
+4. Perform the manual server setup steps (4–8 above).
+5. Enable the timers and confirm a deploy fires successfully for each environment.
+6. Remove legacy Jenkins sudo rules.

--- a/docs/cd-migration-plan.md
+++ b/docs/cd-migration-plan.md
@@ -19,7 +19,7 @@ green commit on the target branch, pulls source, builds locally, migrates, and r
 ```
 Jenkins (any agent)          Production server
 ──────────────────           ──────────────────────────────────────────────
-assemble                     [timer fires every 5 min]
+assemble                     [timer fires every 1 min]
 ktlintCheck                  deploy.sh
 gradle check         ──────▶   git fetch (via deploy key)
 frontend test        status    check GitHub status API (via fine-grained PAT)
@@ -38,7 +38,7 @@ Two separate credentials are needed on the server, owned by the service user:
 
 | Credential       | Type            | Purpose                            | Location on server            |
 |------------------|-----------------|------------------------------------|-------------------------------|
-| Deploy Key       | SSH private key | `git fetch` from GitHub            | `~/.ssh/button_deploy_key`    |
+| Deploy Key       | SSH private key | `git fetch` from GitHub            | `~/.ssh/deploy_key`           |
 | Fine-grained PAT | HTTP token      | Read commit status from GitHub API | `~/.github_token` (chmod 600) |
 
 The fine-grained PAT should be scoped to the `zwalsh/button` repository, with only
@@ -78,21 +78,21 @@ deployment is driven by the server-side deploy scripts and systemd timers.
 
 ### `scripts/deploy.sh`
 
-Parameterized deploy script. Called by both systemd services. Accepts `--env button` or
-`--env testbutton` to control which branch to target and which service to restart. Logic:
+Parameterized deploy script. Called by both systemd services. Accepts `--env prod` or
+`--env test` to control which branch to target and which service to restart. Logic:
 
-1. `git -C ~/src fetch origin`
+1. `git -C ~/button fetch origin`
 2. Resolve target SHA:
-    - `button`: `git rev-parse origin/main`
-    - `testbutton`: tip of most-recently-updated remote branch (`git for-each-ref
+    - `prod`: `git rev-parse origin/main`
+    - `test`: tip of most-recently-updated remote branch (`git for-each-ref
      --sort=-committerdate`)
 3. Read `~/deployed_commit`; exit 0 if already deployed
 4. Query `https://api.github.com/repos/zwalsh/button/commits/$SHA/statuses`; exit 0 if not
    `success`
-5. `git -C ~/src checkout $SHA`
-6. `~/src/gradlew assemble` → produces `~/src/build/distributions/button.tar`
+5. `git -C ~/button checkout $SHA`  // Confirm right place to check out the code.
+6. `~/button/gradlew assemble` → produces `~/button/build/distributions/button.tar`
 7. `mkdir -p ~/releases/$SHA && tar -xf ... -C ~/releases/$SHA`
-8. Run `~/src/db/migrate.sh` (unchanged; reads credentials from `~/button.env` via `find ~`)
+8. Run `~/button/db/migrate.sh` (unchanged; reads credentials from `~/button.env` via `find ~`)
 9. `ln -sfn ~/releases/$SHA ~/releases/current`
 10. `sudo systemctl restart button` (or `testbutton`)
 11. `echo $SHA > ~/deployed_commit`
@@ -104,7 +104,7 @@ Systemd service unit that runs `deploy.sh --env button` as the `button` user.
 
 ### `scripts/button-deploy.timer`
 
-Systemd timer unit that triggers `button-deploy.service` every 5 minutes.
+Systemd timer unit that triggers `button-deploy.service` every 1 minute.
 
 ### `scripts/testbutton-deploy.service`
 
@@ -112,7 +112,7 @@ Systemd service unit that runs `deploy.sh --env testbutton` as the `testbutton` 
 
 ### `scripts/testbutton-deploy.timer`
 
-Systemd timer unit that triggers `testbutton-deploy.service` every 5 minutes.
+Systemd timer unit that triggers `testbutton-deploy.service` every 1 minute.
 
 ## Dependencies on the Server
 
@@ -129,20 +129,20 @@ The following must be present for the service users on the production host:
 
 These cannot be scripted from this repo and must be done by hand:
 
-### 1. Generate the deploy key
+### 1. Generate the deploy key (DONE)
 
 ```bash
-ssh-keygen -t ed25519 -f ~/.ssh/button_deploy_key -C "button-deploy" -N ""
+ssh-keygen -t ed25519 -f ~/.ssh/deploy_key -C "deploy" -N ""
 ```
 
 Run this once; the same keypair can be placed under both `button` and `testbutton` users.
 
-### 2. Register the public key on GitHub
+### 2. Register the public key on GitHub (DONE)
 
 In `https://github.com/zwalsh/button` → Settings → Deploy keys → Add deploy key.
-Paste the contents of `~/.ssh/button_deploy_key.pub`. Select **read-only** (no write access).
+Paste the contents of `~/.ssh/deploy_key.pub`. Select **read-only** (no write access).
 
-### 3. Create the fine-grained PAT
+### 3. Create the fine-grained PAT (DONE)
 
 In GitHub → Settings → Developer Settings → Fine-grained tokens → Generate new token:
 
@@ -151,20 +151,20 @@ In GitHub → Settings → Developer Settings → Fine-grained tokens → Genera
 - Permissions → Repository permissions → Commit statuses: **Read-only**
 - Expiration: **No expiration**
 
-### 4. Set up credentials on the server (repeat for both users)
+### 4. Set up credentials on the server (repeat for both users) (DONE)
 
 As `button` (and separately as `testbutton`):
 
 ```bash
 # Deploy key
 mkdir -p ~/.ssh
-# Copy private key content to ~/.ssh/button_deploy_key
-chmod 600 ~/.ssh/button_deploy_key
+# Copy private key content to ~/.ssh/deploy_key
+chmod 600 ~/.ssh/deploy_key
 
 # SSH config so git uses the deploy key for github.com
 cat >> ~/.ssh/config <<'EOF'
 Host github.com
-    IdentityFile ~/.ssh/button_deploy_key
+    IdentityFile ~/.ssh/deploy_key
     IdentitiesOnly yes
 EOF
 chmod 600 ~/.ssh/config
@@ -174,13 +174,13 @@ echo "ghp_xxxxxxxxxxxxxxxxxxxx" > ~/.github_token
 chmod 600 ~/.github_token
 ```
 
-### 5. Clone the repo on the server (repeat for both users)
+### 5. Clone the repo on the server (repeat for both users) (DONE)
 
 ```bash
-git clone git@github.com:zwalsh/button.git ~/src
+git clone git@github.com:zwalsh/button.git ~/button 
 ```
 
-### 6. Update sudoers
+### 6. Update sudoers (DONE)
 
 The service users need permission to restart their own systemd unit. Add (via `visudo` or a
 file in `/etc/sudoers.d/`):

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -3,14 +3,84 @@
 Runs as a systemd unit (see [button.service](../button.service)).
 
 Requires its own user. The systemd service file specifies a binary within that user's home
-directory, which is assembled by `./gradlew build` with the `application` Gradle plugin.
+directory, which is assembled by `./gradlew assemble` with the `application` Gradle plugin.
+
+## CI/CD Architecture
+
+Jenkins runs CI (build, lint, test) on ephemeral agents and sets a GitHub commit status.
+Deployment is handled separately by `scripts/deploy.sh`, triggered by systemd timers on the
+production server. This means Jenkins does not need to be colocated with the server.
+
+```
+Jenkins (any agent)          Production server
+──────────────────           ──────────────────────────────────────────────
+assemble                     [timer fires every 1 min]
+ktlintCheck                  deploy.sh
+gradle check         ──────▶   git fetch (via deploy key)
+frontend test        status    check GitHub status API (via PAT)
+setBuildStatus ◀────────────   git checkout $SHA
+                               ./gradlew assemble
+                               unpack into ~/releases/$SHA/
+                               db/migrate.sh
+                               ln -sfn ~/releases/$SHA ~/releases/current
+                               sudo systemctl restart button
+                               echo $SHA > ~/deployed_commit
+```
+
+## Environments
+
+- **`button`** (production): deploys the latest commit on `origin/main`.
+- **`testbutton`** (test): deploys the tip of whichever remote branch was most recently updated.
+
+Both wait for the target commit's CI status to be `success` before deploying.
+
+## Credentials
+
+Two credentials are required on the server, owned by the service user:
+
+| Credential       | Type            | Purpose                            | Location                      |
+|------------------|-----------------|------------------------------------|-------------------------------|
+| Deploy Key       | SSH private key | `git fetch` from GitHub            | `~/.ssh/deploy_key`           |
+| Fine-grained PAT | HTTP token      | Read commit status from GitHub API | `~/.github_token` (chmod 600) |
+
+The fine-grained PAT is scoped to `zwalsh/button` with **Commit statuses: Read-only** permission.
+The deploy key is read-only.
+
+## Systemd Units
+
+The timer units in `scripts/` fire `deploy.sh` every minute:
+
+```bash
+sudo cp scripts/button-deploy.service    /etc/systemd/system/
+sudo cp scripts/button-deploy.timer      /etc/systemd/system/
+sudo cp scripts/testbutton-deploy.service /etc/systemd/system/
+sudo cp scripts/testbutton-deploy.timer   /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now button-deploy.timer
+sudo systemctl enable --now testbutton-deploy.timer
+```
+
+View recent deploy logs:
+
+```bash
+journalctl -u button-deploy.service -n 50
+journalctl -u testbutton-deploy.service -n 50
+```
 
 ## Dependencies
 
-Depends on a Postgres database server. Its schema is controlled by liquibase. See [db](../db) and
+Depends on a Postgres database server. Its schema is controlled by Liquibase. See [db](../db) and
 [liquibase.properties](../db/liquibase.properties). The database connection information (that
 isn't configured via environment variables) is configured in
 [hikari.properties](../src/main/resources/hikari.properties).
+
+The following must be present for the service users on the production host:
+
+- **JDK 17**
+- **Gradle wrapper** (`./gradlew` in the repo checkout — downloads Gradle automatically)
+- **Liquibase** on `$PATH`
+- **`jq`** (for parsing the GitHub API JSON response)
+- **`git`** on `$PATH`
 
 ## Environment
 
@@ -21,15 +91,15 @@ Requires a `button.env` environment file in the user's home directory (loaded by
 |--------------------|----------------------------------------------------------------------------------------------|
 | ENV                | The name of the current environment. Controls header configuration, HTTPS usage, etc.        |
 | PORT               | The port that the server should start on.                                                    |
-| HOST               | The hostname at which the server is reachable.                                               | 
-| WS_PROTOCOL        | `ws` or `wss` -- which protocol to use to connect to this server for a WebSocket connection. | 
+| HOST               | The hostname at which the server is reachable.                                               |
+| WS_PROTOCOL        | `ws` or `wss` -- which protocol to use to connect to this server for a WebSocket connection. |
 | DB_NAME            | The name of the Postgres database to connect to.                                             |
 | DB_USER            | The user with which to connect to Postgres.                                                  |
 | DB_PASSWORD        | The password with which to connect to Postgres.                                              |
 | TWILIO_ACCOUNT_SID | The SID of the Twilio account to use for sending SMS. Not required.                          |
 | TWILIO_AUTH_TOKEN  | The auth token of the Twilio account to use for sending SMS. Not required.                   |
-| ADMIN_PHONE        | The phone number to send admin texts to.                                                     | 
-| SENTRY_KOTLIN_DSN  | The Sentry DSN to send Kotlin exceptions to.                                                 | 
-| SENTRY_JS_DSN      | The Sentry DSN to send Javascript exceptions to.                                             | 
+| ADMIN_PHONE        | The phone number to send admin texts to.                                                     |
+| SENTRY_KOTLIN_DSN  | The Sentry DSN to send Kotlin exceptions to.                                                 |
+| SENTRY_JS_DSN      | The Sentry DSN to send Javascript exceptions to.                                             |
 | UMAMI_URL          | The URL of the Umami host to send analytics to.                                              |
 | UMAMI_WEBSITE_ID   | The website id of this deploy of the Button configured in Umami.                             |

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -7,25 +7,9 @@ directory, which is assembled by `./gradlew assemble` with the `application` Gra
 
 ## CI/CD Architecture
 
-Jenkins runs CI (build, lint, test) on ephemeral agents and sets a GitHub commit status.
+Jenkins runs CI (build, lint, test) and sets a GitHub commit status.
 Deployment is handled separately by `scripts/deploy.sh`, triggered by systemd timers on the
-production server. This means Jenkins does not need to be colocated with the server.
-
-```
-Jenkins (any agent)          Production server
-──────────────────           ──────────────────────────────────────────────
-assemble                     [timer fires every 1 min]
-ktlintCheck                  deploy.sh
-gradle check         ──────▶   git fetch (via deploy key)
-frontend test        status    check GitHub status API (via PAT)
-setBuildStatus ◀────────────   git checkout $SHA
-                               ./gradlew assemble
-                               unpack into ~/releases/$SHA/
-                               db/migrate.sh
-                               ln -sfn ~/releases/$SHA ~/releases/current
-                               sudo systemctl restart button
-                               echo $SHA > ~/deployed_commit
-```
+production server.
 
 ## Environments
 
@@ -45,27 +29,6 @@ Two credentials are required on the server, owned by the service user:
 
 The fine-grained PAT is scoped to `zwalsh/button` with **Commit statuses: Read-only** permission.
 The deploy key is read-only.
-
-## Systemd Units
-
-The timer units in `scripts/` fire `deploy.sh` every minute:
-
-```bash
-sudo cp scripts/button-deploy.service    /etc/systemd/system/
-sudo cp scripts/button-deploy.timer      /etc/systemd/system/
-sudo cp scripts/testbutton-deploy.service /etc/systemd/system/
-sudo cp scripts/testbutton-deploy.timer   /etc/systemd/system/
-sudo systemctl daemon-reload
-sudo systemctl enable --now button-deploy.timer
-sudo systemctl enable --now testbutton-deploy.timer
-```
-
-View recent deploy logs:
-
-```bash
-journalctl -u button-deploy.service -n 50
-journalctl -u testbutton-deploy.service -n 50
-```
 
 ## Dependencies
 

--- a/scripts/button-deploy.service
+++ b/scripts/button-deploy.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Button deployment
+After=network.target
+
+[Service]
+Type=oneshot
+User=button
+ExecStart=%h/button/scripts/deploy.sh --env button
+StandardOutput=journal
+StandardError=journal

--- a/scripts/button-deploy.service
+++ b/scripts/button-deploy.service
@@ -5,6 +5,7 @@ After=network.target
 [Service]
 Type=oneshot
 User=button
+EnvironmentFile=%h/button.env
 ExecStart=%h/button/scripts/deploy.sh --env button
 StandardOutput=journal
 StandardError=journal

--- a/scripts/button-deploy.timer
+++ b/scripts/button-deploy.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Button deployment timer
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=1min
+Unit=button-deploy.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -euo pipefail
+
+ENV=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --env) ENV="$2"; shift 2 ;;
+        *) echo "Unknown argument: $1" >&2; exit 1 ;;
+    esac
+done
+
+if [[ "$ENV" != "button" && "$ENV" != "testbutton" ]]; then
+    echo "Usage: $0 --env <button|testbutton>" >&2
+    exit 1
+fi
+
+REPO=~/button
+TOKEN=$(cat ~/.github_token)
+
+# 1. Fetch latest refs
+git -C "$REPO" fetch origin
+
+# 2. Resolve target SHA
+if [[ "$ENV" == "button" ]]; then
+    SHA=$(git -C "$REPO" rev-parse origin/main)
+else
+    SHA=$(git -C "$REPO" for-each-ref \
+        --sort=-committerdate \
+        --format='%(refname:short) %(objectname)' \
+        'refs/remotes/origin/*' | \
+        grep -v 'origin/HEAD' | \
+        awk 'NR==1{print $2}')
+fi
+
+# 3. Exit if already deployed
+DEPLOYED_FILE=~/deployed_commit
+if [[ -f "$DEPLOYED_FILE" ]] && [[ "$(cat "$DEPLOYED_FILE")" == "$SHA" ]]; then
+    exit 0
+fi
+
+# 4. Exit if CI status is not success
+STATUS=$(curl -s "https://api.github.com/repos/zwalsh/button/commits/$SHA/status" \
+    -H "Authorization: token $TOKEN" | jq -r '.state // empty') || true
+if [[ "$STATUS" != "success" ]]; then
+    exit 0
+fi
+
+# 5. Check out the target commit
+git -C "$REPO" checkout -f "$SHA"
+
+# 6. Build
+"$REPO/gradlew" -p "$REPO" assemble
+
+# 7. Unpack into release directory
+RELEASE_DIR=~/releases/$SHA
+mkdir -p "$RELEASE_DIR"
+tar -xf "$REPO/build/distributions/button.tar" -C "$RELEASE_DIR"
+
+# 8. Run database migrations
+"$REPO/db/migrate.sh"
+
+# 9. Atomically update the current symlink
+ln -sfn "$RELEASE_DIR" ~/releases/current
+
+# 10. Restart the service
+sudo systemctl restart "$ENV"
+
+# 11. Record the deployed commit
+echo "$SHA" > "$DEPLOYED_FILE"
+
+# 12. Prune old releases, keeping the 3 most recent
+ls -t ~/releases/ | grep -v '^current$' | tail -n +4 | xargs -I{} rm -rf ~/releases/{}

--- a/scripts/testbutton-deploy.service
+++ b/scripts/testbutton-deploy.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Testbutton deployment
+After=network.target
+
+[Service]
+Type=oneshot
+User=testbutton
+ExecStart=%h/button/scripts/deploy.sh --env testbutton
+StandardOutput=journal
+StandardError=journal

--- a/scripts/testbutton-deploy.service
+++ b/scripts/testbutton-deploy.service
@@ -5,6 +5,7 @@ After=network.target
 [Service]
 Type=oneshot
 User=testbutton
+EnvironmentFile=%h/button.env
 ExecStart=%h/button/scripts/deploy.sh --env testbutton
 StandardOutput=journal
 StandardError=journal

--- a/scripts/testbutton-deploy.timer
+++ b/scripts/testbutton-deploy.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Testbutton deployment timer
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=1min
+Unit=testbutton-deploy.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

- **Jenkinsfile**: Stripped to pure CI — removes `test-release`, `migrate database`, and `release` stages. Jenkins now only builds, lints, tests, and sets a GitHub commit status.
- **`scripts/deploy.sh`**: New server-side deploy script (runs as `button`/`testbutton` user). Polls GitHub status API, checks out the target SHA, builds locally via Gradle, runs Liquibase migrations, atomically symlinks the new release, restarts the systemd service, and prunes old releases (keeps 3).
- **`scripts/{button,testbutton}-deploy.{service,timer}`**: Four systemd unit files that trigger `deploy.sh` every minute as the respective service user.
- **`docs/deploy.md`**: Rewritten to describe the new CI/CD architecture, credentials, and how to install/inspect the timers.
- **`CLAUDE.md`**: Deployment & CI/CD section updated to reflect CI-only Jenkins and server-side deploy scripts.

## Test plan

- [ ] Jenkins CI passes on this branch (build/lint/test/status only — no deploy stages)
- [ ] After merge, perform manual server setup steps 7–8 from `docs/cd-migration-plan.md` (install timers, seed `deployed_commit`)
- [ ] Confirm `button-deploy.timer` fires and deploys `origin/main` successfully
- [ ] Confirm `testbutton-deploy.timer` fires and deploys the most-recently-updated branch
- [ ] Check logs: `journalctl -u button-deploy.service -n 50`
- [ ] Remove legacy Jenkins sudo rules once both environments are confirmed working

🤖 Generated with [Claude Code](https://claude.com/claude-code)