### PR TITLE
Admin contacts: search/filter, 90d press stats

### DIFF
--- a/docs/admin-contacts-improvements/plan.md
+++ b/docs/admin-contacts-improvements/plan.md
@@ -1,0 +1,156 @@
+# Admin Contacts Page Improvements
+
+## Goal
+
+Make the `/admin/contacts` page more useful for managing who receives SMS notifications:
+
+- Search bar + active/inactive filter (SSR, query params, View Transitions API)
+- Last-90-days press count column (sorted descending)
+- Card-based mobile layout
+
+---
+
+## Current State
+
+- `AdminContactController.contactPage()` calls `phoneBookService.contacts()` and renders a table
+- Table columns: Name, Number, Active (emoji), Update (Activate/Deactivate button)
+- `update.js` POSTs to `/admin/contacts/update` and reloads on success
+- Bootstrap 4.4.1 is available via `headSetup()`; jQuery 3.5.1 is already included on this page
+- `ContactPressStatsService.pressStats(TimeRange)` returns `List<ContactPressStat>` sorted by count desc, **only for
+  contacts with ≥ 1 press**
+- `TimeRange` options: TODAY, LAST_7_DAYS, LAST_30_DAYS, YEAR_TO_DATE, ALL_TIME — no 90-day option yet
+
+---
+
+## Plan
+
+### Session 1 — Backend: 90-day press stats + SSR search/filter
+
+**1a. Add `LAST_90_DAYS` to `TimeRange`**
+
+File: `src/main/kotlin/sh/zachwal/button/admin/ContactPressStatsService.kt`
+
+Add `LAST_90_DAYS("Last 90 Days", "90d")` to the enum. Confirm the materialized DAO query and today's real-time query
+both accept a flexible lookback `Instant` so this just works.
+
+Check: `src/main/kotlin/sh/zachwal/button/db/dao/` for the DAO used by `ContactPressStatsService`.
+
+**1b. Merge press stats with full contact list**
+
+`pressStats()` omits zero-press contacts. The page needs all contacts. Change `AdminContactController.contactPage()` to:
+
+```kotlin
+val allContacts = phoneBookService.contacts()
+val stats = contactPressStatsService.pressStats(TimeRange.LAST_90_DAYS)
+    .associateBy { it.contact.id }
+val contactRows = allContacts
+    .map { c -> ContactRow(c, stats[c.id]?.count ?: 0L) }
+    .sortedByDescending { it.pressCount }
+```
+
+Add a local `data class ContactRow(val contact: Contact, val pressCount: Long)` inside the controller (private, no need
+for a shared file).
+
+**1c. Read query params and filter server-side**
+
+The GET handler reads two optional query params:
+
+- `query`: plain text, OR-matched against `contact.name` and `contact.phoneNumber` (case-insensitive)
+- `active`: `true` or `false`; absent means show all
+
+```kotlin
+val query = call.request.queryParameters["query"]?.lowercase()
+val activeFilter = call.request.queryParameters["active"]?.toBooleanStrictOrNull()
+
+val filtered = contactRows
+    .filter { row ->
+        query == null ||
+                row.contact.name.lowercase().contains(query) ||
+                row.contact.phoneNumber.contains(query)
+    }
+    .filter { row ->
+        activeFilter == null || row.contact.active == activeFilter
+    }
+```
+
+Pass `query` and `activeFilter` back to the template so the search box and filter buttons render with their current
+state.
+
+**1d. Search bar + filter UI**
+
+Above the table, render a `<form method="get" action="/admin/contacts">` with:
+
+- A text `<input>` pre-filled with the current `query` value
+- Three filter buttons (All / Active / Inactive) rendered as submit buttons or links with the appropriate `active`
+  param — the selected one gets `btn-primary`, others get `btn-outline-secondary`
+- Auto-submit via a small JS snippet on keyup with a short debounce (250ms)
+
+Using a plain `<form>` GET keeps the URL bookmarkable and the back button sensible.
+
+**1e. View Transitions API**
+
+Add `<meta name="view-transition" content="same-origin">` (or the equivalent `<link>`) in the `<head>` so the browser
+animates between the current and filtered page state. No JS routing needed — the browser handles the cross-document
+transition automatically when both pages opt in.
+
+This gives a smooth fade/slide when submitting the search form without any client-side complexity.
+
+**1f. Add press count to the table**
+
+Add a new "Presses (90d)" column header and render `contactRow.pressCount` as a `td`. The list comes pre-sorted from the
+server so no client-side sort needed.
+
+**1g. Inject `ContactPressStatsService`**
+
+Add it to the `AdminContactController` constructor — it's already a Guice-managed singleton.
+
+---
+
+### Session 2 — Mobile UX: card layout
+
+The table overflows on mobile. Replace it with a responsive card list that's shown on small screens while the table
+remains on larger ones (or replace the table entirely if the card layout reads well on desktop too — decide when
+implementing).
+
+**Card structure per contact:**
+
+```
+┌─────────────────────────────────────────┐
+│ Name Surname          ✅  47 presses    │
+│ +1 (555) 123-4567        [Deactivate]   │
+└─────────────────────────────────────────┘
+```
+
+- **Left side**: name in bold on the first line, phone number in muted text below (`text-muted`)
+- **Right side**: active emoji + press count on the first line, action button below — right-aligned
+
+Bootstrap implementation: each card uses `d-flex justify-content-between align-items-center` inside a `card-body`. No JS
+changes needed — the existing `data-contact-id` / `data-contact-active` attributes on the button work unchanged with
+`update.js`.
+
+**Other mobile details:**
+
+- Search form and filter buttons are already full-width `form-control` / block-level — no extra work needed
+- The card list sits inside the existing `.container` div
+
+---
+
+## Deferred / Out of Scope
+
+- Real-time row updates after Activate/Deactivate (currently reloads — keep that behavior; the reload also re-applies
+  current query params naturally)
+- Sorting by other columns
+- Pagination
+
+---
+
+## File Checklist
+
+| File                                                                            | Session | Change                                                                                                     |
+|---------------------------------------------------------------------------------|---------|------------------------------------------------------------------------------------------------------------|
+| `src/main/kotlin/sh/zachwal/button/admin/ContactPressStatsService.kt`           | 1       | Add `LAST_90_DAYS` to `TimeRange`                                                                          |
+| `src/main/kotlin/sh/zachwal/button/admin/contact/AdminContactController.kt`     | 1       | Inject service, merge + filter data, read query params, render search form + table with press count column |
+| `src/main/kotlin/sh/zachwal/button/sharedhtml/Head.kt` or controller head block | 1       | Add View Transitions meta tag                                                                              |
+| Any DAO that `ContactPressStatsService` uses                                    | 1       | Verify/update for 90-day lookback                                                                          |
+| `src/main/kotlin/sh/zachwal/button/admin/contact/AdminContactController.kt`     | 2       | Replace/augment table with card layout                                                                     |
+| `frontend/src/main/admin/contacts/update.js`                                    | 2       | Auto-submit search form on input (optional, ~5 lines)                                                      |

--- a/frontend/src/main/admin/contacts/search.js
+++ b/frontend/src/main/admin/contacts/search.js
@@ -1,0 +1,12 @@
+document.addEventListener('DOMContentLoaded', function () {
+    var timer;
+    var input = document.querySelector('input[name="query"]');
+    if (input) {
+        input.addEventListener('input', function () {
+            clearTimeout(timer);
+            timer = setTimeout(function () {
+                document.querySelector('form').submit();
+            }, 250);
+        });
+    }
+});

--- a/src/main/kotlin/sh/zachwal/button/admin/ContactPressStatsService.kt
+++ b/src/main/kotlin/sh/zachwal/button/admin/ContactPressStatsService.kt
@@ -13,6 +13,7 @@ enum class TimeRange(val label: String, val queryParam: String) {
     TODAY("Today", "today"),
     LAST_7_DAYS("Last 7 Days", "7d"),
     LAST_30_DAYS("Last 30 Days", "30d"),
+    LAST_90_DAYS("Last 90 Days", "90d"),
     YEAR_TO_DATE("Year to Date", "ytd"),
     ALL_TIME("All Time", "all");
 
@@ -30,12 +31,20 @@ class ContactPressStatsService @Inject constructor(
     private val contactPressCountDAO: ContactPressCountDAO,
     private val pressDAO: PressDAO,
 ) {
+    fun allContactStats(range: TimeRange): List<ContactPressStat> {
+        val statsById = pressStats(range).associateBy { it.contact.id }
+        return contactDAO.selectContacts()
+            .map { c -> statsById[c.id] ?: ContactPressStat(c, 0L) }
+            .sortedByDescending { it.count }
+    }
+
     fun pressStats(range: TimeRange): List<ContactPressStat> {
         val today = LocalDate.now(ZoneOffset.UTC)
         val startDate: LocalDate = when (range) {
             TimeRange.TODAY -> today
             TimeRange.LAST_7_DAYS -> today.minusDays(7)
             TimeRange.LAST_30_DAYS -> today.minusDays(30)
+            TimeRange.LAST_90_DAYS -> today.minusDays(90)
             TimeRange.YEAR_TO_DATE -> LocalDate.of(today.year, 1, 1)
             TimeRange.ALL_TIME -> LocalDate.ofEpochDay(0)
         }

--- a/src/main/kotlin/sh/zachwal/button/admin/contact/AdminContactController.kt
+++ b/src/main/kotlin/sh/zachwal/button/admin/contact/AdminContactController.kt
@@ -10,11 +10,17 @@ import io.ktor.server.routing.Routing
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import kotlinx.html.FlowContent
+import kotlinx.html.FormMethod
+import kotlinx.html.InputType
+import kotlinx.html.a
 import kotlinx.html.body
 import kotlinx.html.button
 import kotlinx.html.div
+import kotlinx.html.form
 import kotlinx.html.h1
 import kotlinx.html.head
+import kotlinx.html.input
+import kotlinx.html.meta
 import kotlinx.html.p
 import kotlinx.html.script
 import kotlinx.html.table
@@ -25,17 +31,21 @@ import kotlinx.html.thead
 import kotlinx.html.title
 import kotlinx.html.tr
 import org.slf4j.LoggerFactory
+import sh.zachwal.button.admin.ContactPressStat
+import sh.zachwal.button.admin.ContactPressStatsService
+import sh.zachwal.button.admin.TimeRange
 import sh.zachwal.button.controller.Controller
-import sh.zachwal.button.db.jdbi.Contact
 import sh.zachwal.button.phone.ContactNotFound
 import sh.zachwal.button.phone.PhoneBookService
 import sh.zachwal.button.phone.UpdatedContact
 import sh.zachwal.button.roles.adminRoute
 import sh.zachwal.button.sharedhtml.headSetup
+import java.net.URLEncoder
 
 @Controller
 class AdminContactController @Inject constructor(
-    private val phoneBookService: PhoneBookService
+    private val phoneBookService: PhoneBookService,
+    private val contactPressStatsService: ContactPressStatsService,
 ) {
 
     private val logger = LoggerFactory.getLogger(AdminContactController::class.java)
@@ -43,13 +53,30 @@ class AdminContactController @Inject constructor(
     internal fun Routing.contactPage() {
         adminRoute("/admin/contacts") {
             get {
-                val contacts = phoneBookService.contacts()
+                val query = call.request.queryParameters["query"]?.lowercase()?.takeIf { it.isNotEmpty() }
+                val activeFilter = call.request.queryParameters["active"]?.toBooleanStrictOrNull()
+
+                val allStats = contactPressStatsService.allContactStats(TimeRange.LAST_90_DAYS)
+                val filtered = allStats
+                    .filter { row ->
+                        query == null ||
+                            row.contact.name.lowercase().contains(query) ||
+                            row.contact.phoneNumber.contains(query)
+                    }
+                    .filter { row ->
+                        activeFilter == null || row.contact.active == activeFilter
+                    }
+
                 call.respondHtml {
                     head {
                         title {
                             +"Contacts"
                         }
                         headSetup()
+                        meta {
+                            name = "view-transition"
+                            content = "same-origin"
+                        }
                         script(
                             src = "https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min" +
                                 ".js"
@@ -58,10 +85,11 @@ class AdminContactController @Inject constructor(
                     }
                     body {
                         div(classes = "container") {
-                            h1 {
+                            h1(classes = "mt-4 text-center") {
                                 +"Contacts"
                             }
-                            contactsTable(contacts)
+                            searchForm(query, activeFilter)
+                            contactsTable(filtered)
                         }
                     }
                 }
@@ -69,52 +97,76 @@ class AdminContactController @Inject constructor(
         }
     }
 
-    private fun FlowContent.contactsTable(contacts: List<Contact>) {
-        if (contacts.isNotEmpty()) {
+    private fun FlowContent.searchForm(query: String?, activeFilter: Boolean?) {
+        form(action = "/admin/contacts", method = FormMethod.get) {
+            if (activeFilter != null) {
+                input(type = InputType.hidden) {
+                    name = "active"
+                    value = activeFilter.toString()
+                }
+            }
+            div(classes = "input-group mb-2") {
+                input(type = InputType.text, classes = "form-control") {
+                    name = "query"
+                    placeholder = "Search by name or number"
+                    value = query ?: ""
+                    attributes["autocomplete"] = "off"
+                }
+                div(classes = "input-group-append") {
+                    button(classes = "btn btn-outline-secondary") {
+                        attributes["type"] = "submit"
+                        +"Search"
+                    }
+                }
+            }
+            div(classes = "mb-3 text-center") {
+                div(classes = "btn-group") {
+                    filterLink("All", null, activeFilter, query)
+                    filterLink("Active", true, activeFilter, query)
+                    filterLink("Inactive", false, activeFilter, query)
+                }
+            }
+        }
+    }
+
+    private fun FlowContent.filterLink(label: String, value: Boolean?, activeFilter: Boolean?, query: String?) {
+        val isSelected = value == activeFilter
+        val btnClass = if (isSelected) "btn btn-primary" else "btn btn-outline-secondary"
+        val params = buildList {
+            if (value != null) add("active=$value")
+            if (query != null) add("query=${URLEncoder.encode(query, "UTF-8")}")
+        }.joinToString("&")
+        val href = "/admin/contacts" + if (params.isNotEmpty()) "?$params" else ""
+        a(href = href, classes = btnClass) {
+            +label
+        }
+    }
+
+    private fun FlowContent.contactsTable(rows: List<ContactPressStat>) {
+        if (rows.isNotEmpty()) {
             table(classes = "table") {
                 thead {
                     tr {
-                        th {
-                            +"Name"
-                        }
-                        th {
-                            +"Number"
-                        }
-                        th {
-                            +"Active"
-                        }
-                        th {
-                            +"Update"
-                        }
+                        th { +"Name" }
+                        th { +"Number" }
+                        th { +"Active" }
+                        th { +"Presses (90d)" }
+                        th { +"Update" }
                     }
                 }
                 tbody {
-                    contacts.forEach { c ->
+                    rows.forEach { row ->
+                        val c = row.contact
                         tr {
+                            td { +c.name }
+                            td { +c.phoneNumber }
                             td {
-                                +c.name
+                                if (c.active) +"✅" else +"❌"
                             }
+                            td { +row.count.toString() }
                             td {
-                                +c.phoneNumber
-                            }
-                            td {
-                                if (c.active) {
-                                    +"✅"
-                                } else {
-                                    +"❌"
-                                }
-                            }
-                            td {
-                                val bootstrapButtonClass = if (c.active) {
-                                    "btn-danger"
-                                } else {
-                                    "btn-success"
-                                }
-                                val buttonText = if (c.active) {
-                                    "Deactivate"
-                                } else {
-                                    "Activate"
-                                }
+                                val bootstrapButtonClass = if (c.active) "btn-danger" else "btn-success"
+                                val buttonText = if (c.active) "Deactivate" else "Activate"
                                 button(classes = "contact-update btn $bootstrapButtonClass") {
                                     attributes["data-contact-id"] = c.id.toString()
                                     attributes["data-contact-active"] = c.active.not().toString()
@@ -127,7 +179,7 @@ class AdminContactController @Inject constructor(
             }
         } else {
             p {
-                +"No pending users"
+                +"No contacts found"
             }
         }
     }

--- a/src/test/kotlin/sh/zachwal/button/admin/ContactPressStatsServiceTest.kt
+++ b/src/test/kotlin/sh/zachwal/button/admin/ContactPressStatsServiceTest.kt
@@ -241,7 +241,64 @@ class ContactPressStatsServiceTest {
         assertThat(result.map { it.count }).containsExactly(10L, 5L, 2L).inOrder()
     }
 
+    // --- allContactStats ---
+
+    @Test
+    fun `allContactStats includes contacts with zero presses`() {
+        val alice = contact(1, "Alice")
+        val bob = contact(2, "Bob")
+        every { contactDAO.selectContacts() } returns listOf(alice, bob)
+        every { contactPressCountDAO.aggregateCountsByContact(any(), any()) } returns mapOf(1 to 5)
+        every { pressDAO.countByContactSince(any()) } returns emptyMap()
+
+        val result = service.allContactStats(TimeRange.LAST_90_DAYS)
+
+        assertThat(result.map { it.contact }).containsExactly(alice, bob)
+    }
+
+    @Test
+    fun `allContactStats sorts by press count descending with zero-press contacts at the end`() {
+        val alice = contact(1, "Alice")
+        val bob = contact(2, "Bob")
+        val carol = contact(3, "Carol")
+        every { contactDAO.selectContacts() } returns listOf(alice, bob, carol)
+        every { contactPressCountDAO.aggregateCountsByContact(any(), any()) } returns mapOf(3 to 10, 1 to 3)
+        every { pressDAO.countByContactSince(any()) } returns emptyMap()
+
+        val result = service.allContactStats(TimeRange.LAST_90_DAYS)
+
+        assertThat(result.map { it.contact }).containsExactly(carol, alice, bob).inOrder()
+        assertThat(result.map { it.count }).containsExactly(10L, 3L, 0L).inOrder()
+    }
+
+    @Test
+    fun `allContactStats returns correct counts for contacts with presses`() {
+        val alice = contact(1, "Alice")
+        every { contactDAO.selectContacts() } returns listOf(alice)
+        every { contactPressCountDAO.aggregateCountsByContact(any(), any()) } returns mapOf(1 to 7)
+        every { pressDAO.countByContactSince(any()) } returns mapOf(1 to 3L)
+
+        val result = service.allContactStats(TimeRange.LAST_90_DAYS)
+
+        assertThat(result).hasSize(1)
+        assertThat(result[0].count).isEqualTo(10L)
+    }
+
     // --- TimeRange.fromParam ---
+
+    @Test
+    fun `pressStats LAST_90_DAYS queries materialized from 90 days ago through yesterday`() {
+        val startSlot = slot<LocalDate>()
+        val endSlot = slot<LocalDate>()
+        every { contactDAO.selectContacts() } returns emptyList()
+        every { contactPressCountDAO.aggregateCountsByContact(capture(startSlot), capture(endSlot)) } returns emptyMap()
+        every { pressDAO.countByContactSince(any()) } returns emptyMap()
+
+        service.pressStats(TimeRange.LAST_90_DAYS)
+
+        assertThat(startSlot.captured).isEqualTo(today.minusDays(90))
+        assertThat(endSlot.captured).isEqualTo(yesterday)
+    }
 
     @Test
     fun `TimeRange fromParam falls back to LAST_30_DAYS for null, empty, and unknown params`() {
@@ -255,6 +312,7 @@ class ContactPressStatsServiceTest {
         assertThat(TimeRange.fromParam("today")).isEqualTo(TimeRange.TODAY)
         assertThat(TimeRange.fromParam("7d")).isEqualTo(TimeRange.LAST_7_DAYS)
         assertThat(TimeRange.fromParam("30d")).isEqualTo(TimeRange.LAST_30_DAYS)
+        assertThat(TimeRange.fromParam("90d")).isEqualTo(TimeRange.LAST_90_DAYS)
         assertThat(TimeRange.fromParam("ytd")).isEqualTo(TimeRange.YEAR_TO_DATE)
         assertThat(TimeRange.fromParam("all")).isEqualTo(TimeRange.ALL_TIME)
     }


### PR DESCRIPTION
## Summary

- **Search bar** with Submit button — GET form, so URLs are bookmarkable and the back button works correctly
- **All / Active / Inactive filter** links, centered on their own row; each preserves the current search query
- **Presses (90d) column** — all contacts shown (including zero-press), sorted by count descending
- **View Transitions** meta tag for smooth cross-document fade on navigation
- `ContactPressStatsService.allContactStats()` — new method (unit tested) that merges the full contact list with 90-day press counts including zero-press contacts
- `LAST_90_DAYS` added to `TimeRange` enum

## Test plan

- [ ] Visit `/admin/contacts` — all contacts visible, sorted by 90d press count descending
- [ ] Type in search box, hit Search — URL updates with `?query=`, results filter by name/number
- [ ] Click Active / Inactive filter — results filter; query param is preserved in the link
- [ ] Click All — clears the active filter
- [ ] Activate/Deactivate a contact — page reloads, re-applies current query params
- [ ] `./gradlew test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)