### PR TITLE
Replace contacts table with card layout

### DIFF
--- a/src/main/kotlin/sh/zachwal/button/admin/contact/AdminContactController.kt
+++ b/src/main/kotlin/sh/zachwal/button/admin/contact/AdminContactController.kt
@@ -23,13 +23,8 @@ import kotlinx.html.input
 import kotlinx.html.meta
 import kotlinx.html.p
 import kotlinx.html.script
-import kotlinx.html.table
-import kotlinx.html.tbody
-import kotlinx.html.td
-import kotlinx.html.th
-import kotlinx.html.thead
+import kotlinx.html.strong
 import kotlinx.html.title
-import kotlinx.html.tr
 import org.slf4j.LoggerFactory
 import sh.zachwal.button.admin.ContactPressStat
 import sh.zachwal.button.admin.ContactPressStatsService
@@ -89,7 +84,7 @@ class AdminContactController @Inject constructor(
                                 +"Contacts"
                             }
                             searchForm(query, activeFilter)
-                            contactsTable(filtered)
+                            contactCards(filtered)
                         }
                     }
                 }
@@ -142,44 +137,33 @@ class AdminContactController @Inject constructor(
         }
     }
 
-    private fun FlowContent.contactsTable(rows: List<ContactPressStat>) {
-        if (rows.isNotEmpty()) {
-            table(classes = "table") {
-                thead {
-                    tr {
-                        th { +"Name" }
-                        th { +"Number" }
-                        th { +"Active" }
-                        th { +"Presses (90d)" }
-                        th { +"Update" }
+    private fun FlowContent.contactCards(rows: List<ContactPressStat>) {
+        if (rows.isEmpty()) {
+            p { +"No contacts found" }
+            return
+        }
+        rows.forEach { row ->
+            val c = row.contact
+            div(classes = "card mb-2") {
+                div(classes = "card-body d-flex justify-content-between align-items-center py-2") {
+                    div {
+                        strong { +c.name }
+                        div(classes = "text-muted") { +c.phoneNumber }
                     }
-                }
-                tbody {
-                    rows.forEach { row ->
-                        val c = row.contact
-                        tr {
-                            td { +c.name }
-                            td { +c.phoneNumber }
-                            td {
-                                if (c.active) +"✅" else +"❌"
-                            }
-                            td { +row.count.toString() }
-                            td {
-                                val bootstrapButtonClass = if (c.active) "btn-danger" else "btn-success"
-                                val buttonText = if (c.active) "Deactivate" else "Activate"
-                                button(classes = "contact-update btn $bootstrapButtonClass") {
-                                    attributes["data-contact-id"] = c.id.toString()
-                                    attributes["data-contact-active"] = c.active.not().toString()
-                                    +buttonText
-                                }
-                            }
+                    div(classes = "text-right") {
+                        div {
+                            if (c.active) +"✅" else +"❌"
+                            +" ${row.count} presses"
+                        }
+                        val bootstrapButtonClass = if (c.active) "btn-danger" else "btn-success"
+                        val buttonText = if (c.active) "Deactivate" else "Activate"
+                        button(classes = "contact-update btn btn-sm $bootstrapButtonClass mt-1") {
+                            attributes["data-contact-id"] = c.id.toString()
+                            attributes["data-contact-active"] = c.active.not().toString()
+                            +buttonText
                         }
                     }
                 }
-            }
-        } else {
-            p {
-                +"No contacts found"
             }
         }
     }


### PR DESCRIPTION
## Summary

- Replaces the contacts table with a Bootstrap card list that renders at all screen sizes
- Each card shows name (bold) and phone number (muted) on the left, active status + 90d press count + action button on the right
- Existing `update.js` behavior (POST + reload) is unchanged — buttons retain the same `data-contact-id` / `data-contact-active` attributes

## Test plan

- [ ] Visit `/admin/contacts` and confirm cards render for all contacts
- [ ] Verify Activate/Deactivate buttons still work and page reloads correctly
- [ ] Check search and active/inactive filter still apply
- [ ] Confirm layout looks reasonable on both mobile and desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)