### PR TITLE
Reduce log noise

### DIFF
--- a/src/main/kotlin/sh/zachwal/button/App.kt
+++ b/src/main/kotlin/sh/zachwal/button/App.kt
@@ -14,6 +14,7 @@ import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.plugins.defaultheaders.DefaultHeaders
 import io.ktor.server.plugins.forwardedheaders.XForwardedHeaders
 import io.ktor.server.plugins.statuspages.StatusPages
+import io.ktor.server.request.path
 import io.ktor.server.routing.routing
 import io.ktor.server.sessions.Sessions
 import io.ktor.server.sessions.cookie
@@ -77,6 +78,9 @@ fun Application.module(testing: Boolean = false) {
 
     install(CallLogging) {
         level = Level.INFO
+        filter { call ->
+            !call.request.path().startsWith("/static")
+        }
     }
     install(DefaultHeaders)
     install(WebSockets) {

--- a/src/main/kotlin/sh/zachwal/button/admin/config/AdminConfigController.kt
+++ b/src/main/kotlin/sh/zachwal/button/admin/config/AdminConfigController.kt
@@ -83,9 +83,7 @@ class AdminConfigController @Inject constructor(
                 val buttonShape = try {
                     ButtonShape.valueOf(shape)
                 } catch (e: IllegalArgumentException) {
-                    logger.error(
-                        "Tried to set button override to $shape, which is not a ButtonShape", e
-                    )
+                    logger.error("Tried to set button override to {}, which is not a ButtonShape", shape, e)
                     call.respond(
                         HttpStatusCode.BadRequest,
                         "Cannot override button shape to $shape"
@@ -93,7 +91,7 @@ class AdminConfigController @Inject constructor(
                     return@post
                 }
 
-                logger.info("Setting button override to $buttonShape")
+                logger.info("Setting button override to {}", buttonShape)
                 buttonConfigService.setOverride(buttonShape)
                 call.respondRedirect("/admin/config")
             }

--- a/src/main/kotlin/sh/zachwal/button/admin/config/ButtonConfigService.kt
+++ b/src/main/kotlin/sh/zachwal/button/admin/config/ButtonConfigService.kt
@@ -56,7 +56,7 @@ class ButtonConfigService @Inject constructor(
     private var buttonShapeOverride: ButtonShape? = null
     fun setOverride(shape: ButtonShape?) {
         buttonShapeOverride = shape
-        logger.info("Set override to $shape")
+        logger.info("Set override to {}", shape)
     }
 
     // This is in memory but should eventually probably go in the database

--- a/src/main/kotlin/sh/zachwal/button/admin/contact/AdminContactController.kt
+++ b/src/main/kotlin/sh/zachwal/button/admin/contact/AdminContactController.kt
@@ -172,7 +172,7 @@ class AdminContactController @Inject constructor(
         adminRoute("/admin/contacts/update") {
             post {
                 val request = call.receive<UpdateContactRequest>()
-                logger.info("Received request to set active=${request.active} for ${request.contactId}")
+                logger.info("Received request to set active={} for {}", request.active, request.contactId)
                 when (
                     val result = phoneBookService.updateContactStatus(
                         request.contactId, request.active
@@ -182,9 +182,7 @@ class AdminContactController @Inject constructor(
                         NotFound, "Contact with id ${request.contactId} does not exist."
                     )
                     is UpdatedContact -> {
-                        logger.info(
-                            "Contact ${result.contact.id} status set to ${result.contact.active}"
-                        )
+                        logger.info("Contact {} status set to {}", result.contact.id, result.contact.active)
                         call.respond("Success")
                     }
                 }

--- a/src/main/kotlin/sh/zachwal/button/auth/contact/ContactTokenCleanupTask.kt
+++ b/src/main/kotlin/sh/zachwal/button/auth/contact/ContactTokenCleanupTask.kt
@@ -11,9 +11,10 @@ class ContactTokenCleanupTask @Inject constructor(private val contactTokenDAO: C
     private val logger = LoggerFactory.getLogger(ContactTokenCleanupTask::class.java)
 
     fun cleanup() {
-        logger.info("Cleaning up expired contact tokens")
-        contactTokenDAO.deleteExpiredBefore(Instant.now()).forEach {
-            logger.info("Deleted contact token $it, expired at ${it.expiration}")
+        val deleted = contactTokenDAO.deleteExpiredBefore(Instant.now())
+        logger.info("Cleaned up {} expired contact tokens", deleted.size)
+        deleted.forEach {
+            logger.debug("Deleted contact token {}, expired at {}", it, it.expiration)
         }
     }
 

--- a/src/main/kotlin/sh/zachwal/button/controller/ControllerCreator.kt
+++ b/src/main/kotlin/sh/zachwal/button/controller/ControllerCreator.kt
@@ -15,13 +15,13 @@ private const val PACKAGE_NAME = "sh.zachwal.button"
 fun Application.createControllers(injector: Injector) {
     val controllers = getControllerClassesWithReflections()
     controllers.forEach { controller ->
-        logger.info("Found controller $controller")
+        logger.info("Found controller {}", controller)
     }
     routing {
         controllers.forEach { controller ->
             val c = injector.getInstance(controller)
             val routeMethods = controller.declaredMethods.filter(Method::isRoutingMethod)
-            logger.info("Controller $controller has ${routeMethods.size} routing methods")
+            logger.info("Controller {} has {} routing methods", controller, routeMethods.size)
             routeMethods.forEach { m ->
                 logger.debug(m.name)
                 m.invoke(c, this@routing)

--- a/src/main/kotlin/sh/zachwal/button/features/ConfigureRoleAuthorization.kt
+++ b/src/main/kotlin/sh/zachwal/button/features/ConfigureRoleAuthorization.kt
@@ -13,7 +13,7 @@ fun configureRoleAuthorization(
     roleService: RoleService
 ) {
     roleBasedAuthorizer.validate { roles, session ->
-        application.log.info("Checking $roles for session ${session.user}")
+        application.log.debug("Checking {} for session {}", roles, session.user)
         val user = userService.getUser(session.user)
         user?.let { roleService.firstRoleOrNull(user, roles) }
     }

--- a/src/main/kotlin/sh/zachwal/button/guice/HikariModule.kt
+++ b/src/main/kotlin/sh/zachwal/button/guice/HikariModule.kt
@@ -19,16 +19,13 @@ class HikariModule : AbstractModule() {
         val hikariConfig = HikariConfig("/hikari.properties")
 
         appConfig.dbNameOverride?.let { override ->
-            logger.info("Overriding configured db name with value from ktor.deployment.db_name=$override")
+            logger.info("Overriding configured db name with value from ktor.deployment.db_name={}", override)
             hikariConfig.dataSourceProperties.setProperty("databaseName", override)
         } ?: run {
             logger.info("No db name override. Continuing with value in hikari.properties.")
         }
         appConfig.dbUserOverride?.let { override ->
-            logger.info(
-                "Overriding configured db user with value from ktor.deployment" +
-                    ".db_user=$override"
-            )
+            logger.info("Overriding configured db user with value from ktor.deployment.db_user={}", override)
             hikariConfig.dataSourceProperties.setProperty("user", override)
         } ?: run {
             logger.info("No db user override. Continuing with value in hikari.properties.")

--- a/src/main/kotlin/sh/zachwal/button/home/HomeController.kt
+++ b/src/main/kotlin/sh/zachwal/button/home/HomeController.kt
@@ -201,7 +201,7 @@ class HomeController @Inject constructor(
         if (token != null) {
             val contactId = contactTokenStore.checkToken(token)
             if (contactId != null) {
-                logger.info("Received valid token associated with id $contactId, creating session.")
+                logger.info("Received valid token associated with id {}, creating session.", contactId)
                 sessionService.createContactSession(call, contactId)
             } else {
                 logger.info("Received token, but it was not associated with a contact id.")

--- a/src/main/kotlin/sh/zachwal/button/home/WebSocketController.kt
+++ b/src/main/kotlin/sh/zachwal/button/home/WebSocketController.kt
@@ -33,15 +33,15 @@ class WebSocketController @Inject constructor(
             val contactSession = call.sessions.get<ContactSessionPrincipal>()
             val contact = contactSession?.contactId?.let { contactDAO.findContact(it) }
             if (contact != null) {
-                logger.info("New connection from contact id=${contact.id} name=${contact.name} at $remote")
+                logger.info("New connection from contact id={} name={} at {}", contact.id, contact.name, remote)
             } else {
-                logger.info("New connection from $remote")
+                logger.info("New connection from {}", remote)
             }
 
             val presser = presserFactory.createPresser(this, remote, contact)
             manager.addPresser(presser)
             presser.watchChannels()
-            logger.info("$remote disconnected")
+            logger.info("{} disconnected", remote)
         }
     }
 }

--- a/src/main/kotlin/sh/zachwal/button/notify/ContactNotifier.kt
+++ b/src/main/kotlin/sh/zachwal/button/notify/ContactNotifier.kt
@@ -66,16 +66,16 @@ class ContactNotifier @Inject constructor(
                 return@launch
             }
             logger.info(
-                "Last notification was at ${lastNotification?.sentDate}, " +
-                    "sending a new one " +
-                    "triggered by contact=${presser.contact} " +
-                    "at remote=${presser.remote()}"
+                "Last notification was at {}, sending a new one triggered by contact={} at remote={}",
+                lastNotification?.sentDate,
+                presser.contact,
+                presser.remote()
             )
             // TODO: Create the notification with the triggering contact id & remote address
             notificationDAO.createNotification()
 
             val contacts = contactsToNotify()
-            logger.info("Sending a notification to ${contacts.size} contacts.")
+            logger.info("Sending a notification to {} contacts.", contacts.size)
             contacts.forEach { c ->
                 val linkForContact = linkForContact(c)
                 controlledContactMessagingService.sendMessage(

--- a/src/main/kotlin/sh/zachwal/button/phone/PhoneController.kt
+++ b/src/main/kotlin/sh/zachwal/button/phone/PhoneController.kt
@@ -130,7 +130,7 @@ class PhoneController @Inject constructor(private val phoneBookService: PhoneBoo
                             "&badNumber=true"
                     )
                 }
-                logger.info("Created contact $contact.")
+                logger.info("Created contact {}.", contact)
                 call.respondRedirect("/phone/postSignup?name=$name")
             }
         }

--- a/src/main/kotlin/sh/zachwal/button/presser/Presser.kt
+++ b/src/main/kotlin/sh/zachwal/button/presser/Presser.kt
@@ -89,7 +89,7 @@ class Presser constructor(
         when (frame) {
             is Text -> handleIncomingText(frame)
             else -> {
-                logger.info("Got unexpected frame: $frame, disconnecting.")
+                logger.info("Got unexpected frame: {}, disconnecting.", frame)
                 observer.disconnected(this@Presser)
                 socketSession.close(CloseReason(Codes.PROTOCOL_ERROR, "Invalid frame type"))
             }

--- a/src/main/kotlin/sh/zachwal/button/presshistory/ContactPressCountMaterializationTask.kt
+++ b/src/main/kotlin/sh/zachwal/button/presshistory/ContactPressCountMaterializationTask.kt
@@ -23,18 +23,18 @@ class ContactPressCountMaterializationTask @Inject constructor(
         val yesterday = today.minusDays(1)
         val contacts = contactDAO.selectActiveContacts()
         for (contact in contacts) {
-            logger.info("Materializing press counts for contact id=${contact.id}, name=${contact.name}")
+            logger.info("Materializing press counts for contact id={}, name={}", contact.id, contact.name)
             val contactId = contact.id
             val firstPressTimestamp = pressDAO.firstPressTimestampForContact(contactId) ?: continue
             val firstPressDate = firstPressTimestamp.toInstant().atZone(ZoneOffset.UTC).toLocalDate()
-            logger.info("Contact's first press date is $firstPressDate")
+            logger.info("Contact's first press date is {}", firstPressDate)
             val lastMaterialized = contactPressCountDAO.findAllForContact(contactId).maxByOrNull { it.date }?.date
-            logger.info("Contact's last materialized date is $lastMaterialized")
+            logger.info("Contact's last materialized date is {}", lastMaterialized)
             val startDate = lastMaterialized?.plusDays(1) ?: firstPressDate
             if (startDate > yesterday) continue
             val pressCounts = pressDAO.aggregatePressCountsByDate(contactId, startDate, yesterday)
             for ((date, count) in pressCounts) {
-                logger.info("Contact pressed $count times on $date")
+                logger.info("Contact pressed {} times on {}", count, date)
                 contactPressCountDAO.upsert(ContactPressCount(contactId, date, count))
             }
         }

--- a/src/main/kotlin/sh/zachwal/button/presshistory/DailyStatsService.kt
+++ b/src/main/kotlin/sh/zachwal/button/presshistory/DailyStatsService.kt
@@ -63,7 +63,7 @@ class DailyStatsService @Inject constructor(
         capacity = 1000,
         onBufferOverflow = BufferOverflow.DROP_LATEST,
     ) { undeliveredDbOp ->
-        logger.error("Dropping a database write due to a buffer overflow: $undeliveredDbOp")
+        logger.error("Dropping a database write due to a buffer overflow: {}", undeliveredDbOp)
     }
 
     // Single-threaded pool for DB writes (consumer of dbOpChannel)
@@ -76,7 +76,7 @@ class DailyStatsService @Inject constructor(
             try {
                 processDbOp(op)
             } catch (e: Exception) {
-                logger.error("Failed to process DB op: $op", e)
+                logger.error("Failed to process DB op: {}", op, e)
             }
         }
     }

--- a/src/main/kotlin/sh/zachwal/button/presshistory/PressLogger.kt
+++ b/src/main/kotlin/sh/zachwal/button/presshistory/PressLogger.kt
@@ -40,7 +40,7 @@ class PressLogger @Inject constructor() : PresserObserver {
                 try {
                     if (pressCounts.isNotEmpty()) {
                         pressCounts.forEach { (name, count) ->
-                            logger.info("$name pressed $count times")
+                            logger.info("{} pressed {} times", name, count)
                         }
                         pressCounts.clear()
                     }

--- a/src/main/kotlin/sh/zachwal/button/roles/RoleAuthorization.kt
+++ b/src/main/kotlin/sh/zachwal/button/roles/RoleAuthorization.kt
@@ -56,10 +56,10 @@ class RoleAuthorization internal constructor(config: Configuration) {
             }
 
             config.provider.authorizationFunction(call, roles, session)?.let {
-                logger.info("Passing user ${session.user} with role $it")
+                logger.debug("Passing user {} with role {}", session.user, it)
                 return@intercept
             } ?: run {
-                logger.info("Failing user ${session.user} for roles $roles")
+                logger.warn("Failing user {} for roles {}", session.user, roles)
                 call.respond(HttpStatusCode.Forbidden)
                 finish()
             }

--- a/src/main/kotlin/sh/zachwal/button/session/DbSessionStorage.kt
+++ b/src/main/kotlin/sh/zachwal/button/session/DbSessionStorage.kt
@@ -29,26 +29,24 @@ class DbSessionStorage(
     private fun dbId(id: String) = "${sessionPrefix}_$id"
 
     override suspend fun invalidate(id: String) {
-        logger.debug("Clearing $id")
+        logger.debug("Clearing {}", id)
         withContext(Dispatchers.IO) {
             sessionDAO.deleteSession(dbId(id))
         }
     }
 
     override suspend fun read(id: String): String {
-        logger.debug("Reading session ${dbId(id)}")
+        logger.debug("Reading session {}", dbId(id))
         return withContext(Dispatchers.IO) {
             val bytes = sessionDAO.getById(dbId(id))?.data
                 ?: throw NoSuchElementException("No session with id ${dbId(id)}")
-            bytes.decodeToString().also {
-                logger.debug("Got $it")
-            }
+            bytes.decodeToString()
         }
     }
 
     override suspend fun write(id: String, value: String) {
         // Note that this function is called every time the session is used.
-        logger.debug("Writing ${dbId(id)} as $value")
+        logger.debug("Writing {}", dbId(id))
         withContext(Dispatchers.IO) {
             val session = Session(
                 id = dbId(id),

--- a/src/main/kotlin/sh/zachwal/button/session/SessionCleanupTask.kt
+++ b/src/main/kotlin/sh/zachwal/button/session/SessionCleanupTask.kt
@@ -11,9 +11,10 @@ class SessionCleanupTask @Inject constructor(private val sessionDAO: SessionDAO)
     private val logger = LoggerFactory.getLogger(SessionCleanupTask::class.java)
 
     fun cleanup() {
-        logger.info("Cleaning up expired sessions")
-        sessionDAO.deleteExpiredBefore(Instant.now()).forEach {
-            logger.info("Deleted session ${it.id}, expired at ${it.expiration}")
+        val deleted = sessionDAO.deleteExpiredBefore(Instant.now())
+        logger.info("Cleaned up {} expired sessions", deleted.size)
+        deleted.forEach {
+            logger.debug("Deleted session {}, expired at {}", it.id, it.expiration)
         }
     }
 

--- a/src/main/kotlin/sh/zachwal/button/session/principals/SessionPrincipal.kt
+++ b/src/main/kotlin/sh/zachwal/button/session/principals/SessionPrincipal.kt
@@ -14,10 +14,12 @@ interface SessionPrincipal {
 
     fun isValid(): Boolean {
         val curEpochMilli = Instant.now().toEpochMilli()
-        logger.info(
-            "Validating $this " +
-                "expiring at $expiration cur time $curEpochMilli, " +
-                "valid: ${expiration > curEpochMilli}"
+        logger.debug(
+            "Validating {} expiring at {} cur time {}, valid: {}",
+            this,
+            expiration,
+            curEpochMilli,
+            expiration > curEpochMilli
         )
         return expiration > curEpochMilli
     }

--- a/src/main/kotlin/sh/zachwal/button/sms/ControlledContactMessagingService.kt
+++ b/src/main/kotlin/sh/zachwal/button/sms/ControlledContactMessagingService.kt
@@ -28,7 +28,7 @@ class ControlledContactMessagingService @Inject constructor(
 
     suspend fun sendMessage(contact: Contact, body: String): MessageStatus {
         if (contact.active.not()) {
-            logger.info("Contact ${contact.id} is not active, not sending message")
+            logger.info("Contact {} is not active, not sending message", contact.id)
             return MessageFailed("Contact is not active")
         }
 

--- a/src/main/kotlin/sh/zachwal/button/sms/StdOutMessagingService.kt
+++ b/src/main/kotlin/sh/zachwal/button/sms/StdOutMessagingService.kt
@@ -15,12 +15,12 @@ class StdOutMessagingService @Inject constructor() : MessagingService {
     private val logger = LoggerFactory.getLogger(StdOutMessagingService::class.java)
 
     override suspend fun validateNumber(phoneNumber: String): PhoneNumberValidation {
-        logger.info("Validating $phoneNumber")
+        logger.info("Validating {}", phoneNumber)
         return ValidNumber("+1$phoneNumber")
     }
 
     override suspend fun sendMessage(toPhoneNumber: String, body: String): MessageStatus {
-        logger.info("Sending $body to $toPhoneNumber")
+        logger.info("Sending {} to {}", body, toPhoneNumber)
         return MessageQueued(UUID.randomUUID().toString(), Instant.now())
     }
 }

--- a/src/main/kotlin/sh/zachwal/button/sms/TwilioMessagingService.kt
+++ b/src/main/kotlin/sh/zachwal/button/sms/TwilioMessagingService.kt
@@ -75,7 +75,7 @@ class TwilioMessagingService constructor(
 
             when (message.status) {
                 QUEUED, ACCEPTED -> {
-                    logger.info("Sent message to $maskedNumber with id ${message.sid}.")
+                    logger.info("Sent message to {} with id {}.", maskedNumber, message.sid)
 
                     MessageQueued(
                         id = message.sid,
@@ -84,16 +84,16 @@ class TwilioMessagingService constructor(
                 }
                 FAILED -> {
                     logger.warn(
-                        "Failed to send message to $maskedNumber: ${message.sid}, " +
-                            "${message.errorMessage}."
+                        "Failed to send message to {}: {}, {}.",
+                        maskedNumber, message.sid, message.errorMessage
                     )
 
                     MessageFailed(message.errorMessage)
                 }
                 else -> {
                     logger.error(
-                        "Got unhandled message status from Twilio when sending message to " +
-                            "$maskedNumber: ${message.status}, ${message.errorMessage}"
+                        "Got unhandled message status from Twilio when sending message to {}: {}, {}",
+                        maskedNumber, message.status, message.errorMessage
                     )
                     throw RuntimeException("Unhandled Twilio message status: ${message.status}")
                 }

--- a/src/main/kotlin/sh/zachwal/button/users/UserService.kt
+++ b/src/main/kotlin/sh/zachwal/button/users/UserService.kt
@@ -15,7 +15,7 @@ class UserService @Inject constructor(private val userDAO: UserDAO) {
         return try {
             userDAO.getByUsername(username)
         } catch (e: Exception) {
-            logger.info("Error retrieving user $username.", e)
+            logger.warn("Error retrieving user {}", username, e)
             null
         }
     }
@@ -24,7 +24,7 @@ class UserService @Inject constructor(private val userDAO: UserDAO) {
         return try {
             userDAO.getById(id)
         } catch (e: Exception) {
-            logger.info("User with id $id could not be found", e)
+            logger.warn("User with id {} could not be found", id, e)
             null
         }
     }
@@ -33,7 +33,7 @@ class UserService @Inject constructor(private val userDAO: UserDAO) {
         try {
             BCrypt.checkpw(password, it.hashedPassword)
         } catch (e: Exception) {
-            logger.warn("Failed to check password for user $username", e)
+            logger.warn("Failed to check password for user {}", username, e)
             false
         }
     }
@@ -43,7 +43,7 @@ class UserService @Inject constructor(private val userDAO: UserDAO) {
         return try {
             userDAO.createUser(username, hash)
         } catch (e: UnableToExecuteStatementException) {
-            logger.error("Failed to create user $username", e)
+            logger.error("Failed to create user {}", username, e)
             null
         }
     }

--- a/src/main/kotlin/sh/zachwal/button/wrapped/WrappedService.kt
+++ b/src/main/kotlin/sh/zachwal/button/wrapped/WrappedService.kt
@@ -93,14 +93,14 @@ class WrappedService @Inject constructor(
         )
 
         contactIds.forEach { contactId ->
-            logger.info("Generating link for $contactId")
+            logger.info("Generating link for {}", contactId)
             val wrappedId = randomStringGenerator.newToken(20)
             val wrappedLink = WrappedLink(
                 wrappedId,
                 year,
                 contactId
             )
-            logger.info("Generated link with id $wrappedId for year $year.")
+            logger.info("Generated link with id {} for year {}.", wrappedId, year)
             wrappedDAO.insertWrappedLink(wrappedLink)
         }
     }
@@ -111,7 +111,7 @@ class WrappedService @Inject constructor(
 
     fun sendWrappedNotification(year: Int) {
         val links = wrappedDAO.wrappedLinks().filter { it.year == year }
-        logger.info("Sending ${links.size} wrapped notifications for year $year.")
+        logger.info("Sending {} wrapped notifications for year {}.", links.size, year)
 
         scope.launch {
             links.forEach { l ->
@@ -119,7 +119,7 @@ class WrappedService @Inject constructor(
                 val linkForContact = "$link/wrapped/$year/${l.wrappedId}"
                 val message = "What a year, ${contact.name}!" +
                     " Check out your Button Wrapped, $year: $linkForContact"
-                logger.info("Sending message to ${contact.id}: $message")
+                logger.info("Sending message to {}: {}", contact.id, message)
                 controlledContactMessagingService.sendMessage(
                     contact = contact,
                     body = message
@@ -132,7 +132,7 @@ class WrappedService @Inject constructor(
 
     private fun wrappedRanks(fromInstant: Instant, toInstant: Instant): List<WrappedRank> {
         return wrappedRanksCache.get(fromInstant to toInstant) {
-            logger.info("Fetching wrapped ranks for $fromInstant to $toInstant.")
+            logger.info("Fetching wrapped ranks for {} to {}.", fromInstant, toInstant)
             wrappedDAO.wrappedRanks(fromInstant, toInstant)
         }
     }
@@ -153,7 +153,7 @@ class WrappedService @Inject constructor(
     }
 
     private fun buildWrapped(year: Int, contact: Contact): Wrapped {
-        logger.info("Building wrapped for $year and contact=$contact")
+        logger.info("Building wrapped for {} and contact={}", year, contact)
         val presses = wrappedDAO.selectBetweenForContact(
             begin = startOfYearInstant(year),
             end = endOfYearInstant(year),


### PR DESCRIPTION
## Summary

Applies the same log-reduction patterns from dailygames ([#109](https://github.com/zwalsh/dailygames/pull/109)) to this project.

- **Filter static assets from CallLogging** — every page load generated multiple log lines for JS/CSS/image fetches; these are now suppressed at INFO
- **Downgrade noisy per-request session logs to DEBUG** — session read/write/validate fire on every authenticated request; also removes the log that dumped the full serialized session value
- **Downgrade role-pass to DEBUG, upgrade role-fail to WARN** — successful auth is not interesting at INFO; denied access is worth a WARN
- **Collapse cleanup logs to a summary** — session and contact-token hourly cleanups now log a single INFO count instead of one line per deleted row (details at DEBUG)
- **Replace Kotlin string interpolation with SLF4J `{}` placeholders** — avoids string construction when the level is disabled; also fixes two `UserService` exception catches that were incorrectly logged at INFO (database errors → WARN)

## Test plan

- [x] All tests pass (`./gradlew test`)
- [x] ktlint clean (`./gradlew ktlintCheck` runs as pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)