### PR TITLE
Phase 1b: notification filtering, preferences endpoint, settings UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ npm --prefix frontend test            # Run tests
 
 **Side Effects**: Use observer pattern (e.g., `PressHistoryObserver`) rather than inline side effects in services.
 
-**Testing**: Backend uses TestContainers with PostgreSQL for integration tests. Frontend uses Vitest + jsdom.
+**Testing**: Backend uses TestContainers with PostgreSQL for DAO/DB integration tests. Frontend uses Vitest + jsdom. For HTTP-layer tests (form parsing, redirects, auth gating), use `withContactTestApp` from `src/test/kotlin/sh/zachwal/button/testing/KtorTestApp.kt` — see the KDoc there for when to reach for it. Prefer unit tests (mockk) for service logic; keep Ktor integration tests to one file per controller, testing only what cannot be exercised without a real request cycle.
 
 ## External Integrations
 

--- a/frontend/src/main/contact/toast.js
+++ b/frontend/src/main/contact/toast.js
@@ -1,0 +1,9 @@
+
+$(document).ready(function() {
+    var alert = $('#savedAlert');
+    if (alert.length) {
+        setTimeout(function() {
+            alert.alert('close');
+        }, 3000);
+    }
+});

--- a/src/main/kotlin/sh/zachwal/button/contact/ContactController.kt
+++ b/src/main/kotlin/sh/zachwal/button/contact/ContactController.kt
@@ -16,6 +16,7 @@ import io.ktor.server.routing.post
 import io.ktor.server.sessions.get
 import io.ktor.server.sessions.sessions
 import kotlinx.html.ButtonType
+import kotlinx.html.DIV
 import kotlinx.html.FlowContent
 import kotlinx.html.FormMethod
 import kotlinx.html.InputType
@@ -39,12 +40,12 @@ import kotlinx.html.td
 import kotlinx.html.th
 import kotlinx.html.title
 import kotlinx.html.tr
-import kotlinx.html.unsafe
 import sh.zachwal.button.controller.Controller
 import sh.zachwal.button.db.dao.ContactDAO
 import sh.zachwal.button.db.jdbi.Contact
 import sh.zachwal.button.roles.contactRoute
 import sh.zachwal.button.session.principals.ContactSessionPrincipal
+import sh.zachwal.button.sharedhtml.card
 import sh.zachwal.button.sharedhtml.headSetup
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -56,57 +57,51 @@ class ContactController @Inject constructor(
     private val contactDataService: ContactDataService,
 ) {
 
-    private fun FlowContent.contactInfoCard(contact: Contact) {
-        div(classes = "card mt-4") {
-            div(classes = "card-header") { +"Contact Info" }
-            div(classes = "card-body p-0") {
-                table(classes = "table mb-0") {
-                    tr {
-                        th {
-                            scope = ThScope.row
-                            +"Name"
-                        }
-                        td { +contact.name }
+    private fun DIV.contactInfoCard(contact: Contact) {
+        card(cardHeader = "Contact Info", classes = "mt-4", cardBodyClasses = "card-body p-0") {
+            table(classes = "table mb-0") {
+                tr {
+                    th {
+                        scope = ThScope.row
+                        +"Name"
                     }
-                    tr {
-                        th {
-                            scope = ThScope.row
-                            +"Phone number"
-                        }
-                        td { +contact.phoneNumber }
+                    td { +contact.name }
+                }
+                tr {
+                    th {
+                        scope = ThScope.row
+                        +"Phone number"
                     }
+                    td { +contact.phoneNumber }
                 }
             }
         }
     }
 
-    private fun FlowContent.notificationSettingsCard(contact: Contact) {
-        div(classes = "card mt-4") {
-            div(classes = "card-header") { +"Notification Settings" }
-            div(classes = "card-body") {
-                form(action = "/contact/preferences", method = FormMethod.post) {
-                    div(classes = "form-group") {
-                        div(classes = "custom-control custom-switch") {
-                            input(type = InputType.checkBox, classes = "custom-control-input") {
-                                id = "notificationsEnabled"
-                                name = "notificationsEnabled"
-                                checked = contact.notificationPreferences.notificationsEnabled
-                            }
-                            label(classes = "custom-control-label") {
-                                attributes["for"] = "notificationsEnabled"
-                                +"Receive text messages from The Button"
-                            }
+    private fun DIV.notificationSettingsCard(contact: Contact) {
+        card(cardHeader = "Notification Settings", classes = "mt-4") {
+            form(action = "/contact/preferences", method = FormMethod.post) {
+                div(classes = "form-group") {
+                    div(classes = "custom-control custom-switch") {
+                        input(type = InputType.checkBox, classes = "custom-control-input") {
+                            id = "notificationsEnabled"
+                            name = "notificationsEnabled"
+                            checked = contact.notificationPreferences.notificationsEnabled
                         }
-                        if (!contact.notificationPreferences.notificationsEnabled) {
-                            p(classes = "text-muted mt-2 mb-0") {
-                                +"You won't receive any texts until you turn this back on."
-                            }
+                        label(classes = "custom-control-label") {
+                            attributes["for"] = "notificationsEnabled"
+                            +"Receive text messages from The Button"
                         }
                     }
-                    div(classes = "d-flex justify-content-end") {
-                        button(type = ButtonType.submit, classes = "btn btn-primary") {
-                            +"Save"
+                    if (!contact.notificationPreferences.notificationsEnabled) {
+                        p(classes = "text-muted mt-2 mb-0") {
+                            +"You won't receive any texts until you turn this back on."
                         }
+                    }
+                }
+                div(classes = "d-flex justify-content-end") {
+                    button(type = ButtonType.submit, classes = "btn btn-primary") {
+                        +"Save"
                     }
                 }
             }
@@ -120,7 +115,7 @@ class ContactController @Inject constructor(
             +"Settings saved."
             button(classes = "close") {
                 attributes["data-dismiss"] = "alert"
-                span { unsafe { +"&times;" } }
+                span { +"×" }
             }
         }
     }
@@ -139,7 +134,6 @@ class ContactController @Inject constructor(
                         title { +"Settings" }
                         headSetup()
                         script(src = "https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js") {}
-                        script(src = "https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js") {}
                         script(src = "/static/src/contact/toast.js") {}
                     }
                     body {
@@ -213,7 +207,11 @@ class ContactController @Inject constructor(
                 val contactSession = call.sessions.get<ContactSessionPrincipal>()!!
                 val params = call.receiveParameters()
                 val notificationsEnabled = params["notificationsEnabled"] != null
-                contactDAO.updateNotificationPreferences(contactSession.contactId, notificationsEnabled)
+                val updated = contactDAO.updateNotificationPreferences(contactSession.contactId, notificationsEnabled)
+                if (updated == null) {
+                    call.respond(HttpStatusCode.NotFound, "Contact not found")
+                    return@post
+                }
                 call.respondRedirect("/contact?saved=true")
             }
         }

--- a/src/main/kotlin/sh/zachwal/button/contact/ContactController.kt
+++ b/src/main/kotlin/sh/zachwal/button/contact/ContactController.kt
@@ -15,22 +15,34 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.sessions.get
 import io.ktor.server.sessions.sessions
+import kotlinx.html.ButtonType
+import kotlinx.html.FlowContent
+import kotlinx.html.FormMethod
+import kotlinx.html.InputType
 import kotlinx.html.ThScope
 import kotlinx.html.a
 import kotlinx.html.body
 import kotlinx.html.button
 import kotlinx.html.div
+import kotlinx.html.form
 import kotlinx.html.h1
 import kotlinx.html.h2
 import kotlinx.html.head
+import kotlinx.html.id
+import kotlinx.html.input
+import kotlinx.html.label
 import kotlinx.html.p
+import kotlinx.html.script
+import kotlinx.html.span
 import kotlinx.html.table
 import kotlinx.html.td
 import kotlinx.html.th
 import kotlinx.html.title
 import kotlinx.html.tr
+import kotlinx.html.unsafe
 import sh.zachwal.button.controller.Controller
 import sh.zachwal.button.db.dao.ContactDAO
+import sh.zachwal.button.db.jdbi.Contact
 import sh.zachwal.button.roles.contactRoute
 import sh.zachwal.button.session.principals.ContactSessionPrincipal
 import sh.zachwal.button.sharedhtml.headSetup
@@ -44,43 +56,100 @@ class ContactController @Inject constructor(
     private val contactDataService: ContactDataService,
 ) {
 
-    internal fun Routing.contactInfo() {
+    private fun FlowContent.contactInfoCard(contact: Contact) {
+        div(classes = "card mt-4") {
+            div(classes = "card-header") { +"Contact Info" }
+            div(classes = "card-body p-0") {
+                table(classes = "table mb-0") {
+                    tr {
+                        th {
+                            scope = ThScope.row
+                            +"Name"
+                        }
+                        td { +contact.name }
+                    }
+                    tr {
+                        th {
+                            scope = ThScope.row
+                            +"Phone number"
+                        }
+                        td { +contact.phoneNumber }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun FlowContent.notificationSettingsCard(contact: Contact) {
+        div(classes = "card mt-4") {
+            div(classes = "card-header") { +"Notification Settings" }
+            div(classes = "card-body") {
+                form(action = "/contact/preferences", method = FormMethod.post) {
+                    div(classes = "form-group") {
+                        div(classes = "custom-control custom-switch") {
+                            input(type = InputType.checkBox, classes = "custom-control-input") {
+                                id = "notificationsEnabled"
+                                name = "notificationsEnabled"
+                                checked = contact.notificationPreferences.notificationsEnabled
+                            }
+                            label(classes = "custom-control-label") {
+                                attributes["for"] = "notificationsEnabled"
+                                +"Receive text messages from The Button"
+                            }
+                        }
+                        if (!contact.notificationPreferences.notificationsEnabled) {
+                            p(classes = "text-muted mt-2 mb-0") {
+                                +"You won't receive any texts until you turn this back on."
+                            }
+                        }
+                    }
+                    div(classes = "d-flex justify-content-end") {
+                        button(type = ButtonType.submit, classes = "btn btn-primary") {
+                            +"Save"
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun FlowContent.savedAlert() {
+        div(classes = "alert alert-success alert-dismissible fade show fixed-bottom mb-0") {
+            id = "savedAlert"
+            attributes["role"] = "alert"
+            +"Settings saved."
+            button(classes = "close") {
+                attributes["data-dismiss"] = "alert"
+                span { unsafe { +"&times;" } }
+            }
+        }
+    }
+
+    internal fun Routing.contactSettings() {
         contactRoute("/contact") {
             get {
                 val contactSession = call.sessions.get<ContactSessionPrincipal>()!!
                 val contact = contactDAO.findContact(contactSession.contactId) ?: run {
-                    call.respond(
-                        HttpStatusCode.NotFound,
-                        "Contact not found"
-                    )
+                    call.respond(HttpStatusCode.NotFound, "Contact not found")
                     return@get
                 }
+                val saved = call.request.queryParameters["saved"] == "true"
                 call.respondHtml {
                     head {
-                        title { +"Contact" }
+                        title { +"Settings" }
                         headSetup()
+                        script(src = "https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js") {}
+                        script(src = "https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js") {}
+                        script(src = "/static/src/contact/toast.js") {}
                     }
                     body {
                         div(classes = "container") {
-                            h1(classes = "mt-4 mx-2") {
-                                +"Contact Info"
-                            }
-                            table(classes = "table mt-4") {
-                                tr {
-                                    th {
-                                        scope = ThScope.row
-                                        +"Name"
-                                    }
-                                    td { +contact.name }
-                                }
-                                tr {
-                                    th {
-                                        scope = ThScope.row
-                                        +"Phone number"
-                                    }
-                                    td { +contact.phoneNumber }
-                                }
-                            }
+                            h1(classes = "mt-4 text-center font-weight-bold") { +"Settings" }
+                            contactInfoCard(contact)
+                            notificationSettingsCard(contact)
+                        }
+                        if (saved) {
+                            savedAlert()
                         }
                     }
                 }

--- a/src/main/kotlin/sh/zachwal/button/contact/ContactController.kt
+++ b/src/main/kotlin/sh/zachwal/button/contact/ContactController.kt
@@ -45,8 +45,10 @@ import sh.zachwal.button.db.dao.ContactDAO
 import sh.zachwal.button.db.jdbi.Contact
 import sh.zachwal.button.roles.contactRoute
 import sh.zachwal.button.session.principals.ContactSessionPrincipal
+import sh.zachwal.button.sharedhtml.bootstrapJs
 import sh.zachwal.button.sharedhtml.card
 import sh.zachwal.button.sharedhtml.headSetup
+import sh.zachwal.button.sharedhtml.jqueryJs
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -133,7 +135,8 @@ class ContactController @Inject constructor(
                     head {
                         title { +"Settings" }
                         headSetup()
-                        script(src = "https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js") {}
+                        jqueryJs()
+                        bootstrapJs()
                         script(src = "/static/src/contact/toast.js") {}
                     }
                     body {

--- a/src/main/kotlin/sh/zachwal/button/contact/ContactController.kt
+++ b/src/main/kotlin/sh/zachwal/button/contact/ContactController.kt
@@ -5,11 +5,14 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
 import io.ktor.server.html.respondHtml
+import io.ktor.server.request.receiveParameters
 import io.ktor.server.response.header
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondOutputStream
+import io.ktor.server.response.respondRedirect
 import io.ktor.server.routing.Routing
 import io.ktor.server.routing.get
+import io.ktor.server.routing.post
 import io.ktor.server.sessions.get
 import io.ktor.server.sessions.sessions
 import kotlinx.html.ThScope
@@ -131,6 +134,18 @@ class ContactController @Inject constructor(
                         }
                     }
                 }
+            }
+        }
+    }
+
+    internal fun Routing.contactPreferences() {
+        contactRoute("/contact/preferences") {
+            post {
+                val contactSession = call.sessions.get<ContactSessionPrincipal>()!!
+                val params = call.receiveParameters()
+                val notificationsEnabled = params["notificationsEnabled"] != null
+                contactDAO.updateNotificationPreferences(contactSession.contactId, notificationsEnabled)
+                call.respondRedirect("/contact?saved=true")
             }
         }
     }

--- a/src/main/kotlin/sh/zachwal/button/notify/ContactNotifier.kt
+++ b/src/main/kotlin/sh/zachwal/button/notify/ContactNotifier.kt
@@ -93,7 +93,11 @@ class ContactNotifier @Inject constructor(
         val active = contactDAO.selectActiveContacts()
         val contacts = active.filter { c ->
             val enabled = c.notificationPreferences.notificationsEnabled
-            if (!enabled) logger.debug("Skipping contact ${c.id}: notifications disabled")
+            if (enabled) {
+                logger.info("Sending notification to contact id=${c.id} name=${c.name}")
+            } else {
+                logger.info("Skipping contact id=${c.id} name=${c.name}: notifications disabled")
+            }
             enabled
         }
         val endDate = LocalDate.now()

--- a/src/main/kotlin/sh/zachwal/button/notify/ContactNotifier.kt
+++ b/src/main/kotlin/sh/zachwal/button/notify/ContactNotifier.kt
@@ -77,6 +77,7 @@ class ContactNotifier @Inject constructor(
             val contacts = contactsToNotify()
             logger.info("Sending a notification to {} contacts.", contacts.size)
             contacts.forEach { c ->
+                logger.info("Sending notification to contact id=${c.id} name=${c.name}")
                 val linkForContact = linkForContact(c)
                 controlledContactMessagingService.sendMessage(
                     contact = c,
@@ -93,9 +94,7 @@ class ContactNotifier @Inject constructor(
         val active = contactDAO.selectActiveContacts()
         val contacts = active.filter { c ->
             val enabled = c.notificationPreferences.notificationsEnabled
-            if (enabled) {
-                logger.info("Sending notification to contact id=${c.id} name=${c.name}")
-            } else {
+            if (!enabled) {
                 logger.info("Skipping contact id=${c.id} name=${c.name}: notifications disabled")
             }
             enabled

--- a/src/main/kotlin/sh/zachwal/button/notify/ContactNotifier.kt
+++ b/src/main/kotlin/sh/zachwal/button/notify/ContactNotifier.kt
@@ -90,7 +90,12 @@ class ContactNotifier @Inject constructor(
      * Prioritized list of contacts based on recent press activity.
      */
     private fun contactsToNotify(): List<Contact> {
-        val contacts = contactDAO.selectActiveContacts()
+        val active = contactDAO.selectActiveContacts()
+        val contacts = active.filter { c ->
+            val enabled = c.notificationPreferences.notificationsEnabled
+            if (!enabled) logger.debug("Skipping contact ${c.id}: notifications disabled")
+            enabled
+        }
         val endDate = LocalDate.now()
         val startDate = endDate.minusDays(90)
         val aggregatedCounts = contactPressCountDAO.aggregateCountsByContact(startDate, endDate)

--- a/src/main/kotlin/sh/zachwal/button/sharedhtml/Card.kt
+++ b/src/main/kotlin/sh/zachwal/button/sharedhtml/Card.kt
@@ -6,6 +6,7 @@ import kotlinx.html.div
 fun DIV.card(
     cardHeader: String? = null,
     classes: String = "mt-4 h-100",
+    cardBodyClasses: String = "card-body",
     cardBody: DIV.() -> Unit,
 ) {
     div(classes = "card $classes") {
@@ -14,6 +15,6 @@ fun DIV.card(
                 +cardHeader
             }
         }
-        div(classes = "card-body", block = cardBody)
+        div(classes = cardBodyClasses, block = cardBody)
     }
 }

--- a/src/main/kotlin/sh/zachwal/button/sharedhtml/Head.kt
+++ b/src/main/kotlin/sh/zachwal/button/sharedhtml/Head.kt
@@ -17,6 +17,14 @@ fun HEAD.bootstrapCss() {
     )
 }
 
+fun HEAD.jqueryJs() {
+    script(src = "https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js") {}
+}
+
+fun HEAD.bootstrapJs() {
+    script(src = "https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.bundle.min.js") {}
+}
+
 fun HEAD.favicon() {
     link(href = "/static/favicon.png", rel = "icon", type = "image/png")
 }

--- a/src/test/kotlin/sh/zachwal/button/contact/ContactControllerTest.kt
+++ b/src/test/kotlin/sh/zachwal/button/contact/ContactControllerTest.kt
@@ -1,0 +1,64 @@
+package sh.zachwal.button.contact
+
+import io.ktor.client.plugins.cookies.HttpCookies
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.routing.routing
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import sh.zachwal.button.db.dao.ContactDAO
+import sh.zachwal.button.db.jdbi.contact
+import sh.zachwal.button.testing.withContactTestApp
+import kotlin.test.assertEquals
+
+internal class ContactControllerTest {
+
+    private val contactDAO = mockk<ContactDAO>()
+    private val contactDataService = mockk<ContactDataService>()
+    private val controller = ContactController(contactDAO, contactDataService)
+
+    @Test
+    fun `POST preferences with notificationsEnabled present calls DAO with true`() =
+        withContactTestApp(contactId = 1) {
+            routing { with(controller) { contactPreferences() } }
+            every { contactDAO.updateNotificationPreferences(1, true) } returns contact(id = 1)
+
+            val client = createClient { install(HttpCookies) }
+            client.get("/test/set-session")
+
+            val response = client.post("/contact/preferences") {
+                contentType(ContentType.Application.FormUrlEncoded)
+                setBody("notificationsEnabled=on")
+            }
+
+            assertEquals(HttpStatusCode.Found, response.status)
+            assertEquals("/contact?saved=true", response.headers[HttpHeaders.Location])
+            verify { contactDAO.updateNotificationPreferences(1, true) }
+        }
+
+    @Test
+    fun `POST preferences with notificationsEnabled absent calls DAO with false`() =
+        withContactTestApp(contactId = 1) {
+            routing { with(controller) { contactPreferences() } }
+            every { contactDAO.updateNotificationPreferences(1, false) } returns contact(id = 1)
+
+            val client = createClient { install(HttpCookies) }
+            client.get("/test/set-session")
+
+            val response = client.post("/contact/preferences") {
+                contentType(ContentType.Application.FormUrlEncoded)
+                setBody("")
+            }
+
+            assertEquals(HttpStatusCode.Found, response.status)
+            assertEquals("/contact?saved=true", response.headers[HttpHeaders.Location])
+            verify { contactDAO.updateNotificationPreferences(1, false) }
+        }
+}

--- a/src/test/kotlin/sh/zachwal/button/notify/ContactNotifierTest.kt
+++ b/src/test/kotlin/sh/zachwal/button/notify/ContactNotifierTest.kt
@@ -199,6 +199,23 @@ internal class ContactNotifierTest {
     }
 
     @Test
+    fun `does not notify contacts with notifications disabled`() {
+        val disabledContact = contact(id = 3, name = "Opted Out", phoneNumber = "+18005550000", notificationsEnabled = false)
+        every { notificationDAO.getLatestNotification() } returns Notification(
+            1,
+            Instant.now().minus(25, ChronoUnit.HOURS)
+        )
+        every { contactDao.selectActiveContacts() } returns listOf(zachContact, disabledContact)
+
+        runBlocking {
+            notifier.pressed(presser)
+        }
+
+        coVerify(timeout = 2000) { messagingService.sendMessage(zachContact, any()) }
+        coVerify(exactly = 0, timeout = 1000) { messagingService.sendMessage(disabledContact, any()) }
+    }
+
+    @Test
     fun `creates new notification record`() {
         val overOneDayAgo = Instant.now().minus(25, ChronoUnit.HOURS)
         every { notificationDAO.getLatestNotification() } returns Notification(1, overOneDayAgo)

--- a/src/test/kotlin/sh/zachwal/button/testing/KtorTestApp.kt
+++ b/src/test/kotlin/sh/zachwal/button/testing/KtorTestApp.kt
@@ -1,5 +1,6 @@
 package sh.zachwal.button.testing
 
+import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.Application
 import io.ktor.server.application.call
 import io.ktor.server.application.install
@@ -80,7 +81,7 @@ private fun Application.installContactTestPlugins(contactId: Int) {
                     expiration = Instant.now().plusSeconds(3600).toEpochMilli()
                 )
             )
-            call.respond(io.ktor.http.HttpStatusCode.OK)
+            call.respond(HttpStatusCode.OK)
         }
     }
 }

--- a/src/test/kotlin/sh/zachwal/button/testing/KtorTestApp.kt
+++ b/src/test/kotlin/sh/zachwal/button/testing/KtorTestApp.kt
@@ -1,0 +1,86 @@
+package sh.zachwal.button.testing
+
+import io.ktor.server.application.Application
+import io.ktor.server.application.call
+import io.ktor.server.application.install
+import io.ktor.server.auth.Authentication
+import io.ktor.server.auth.session
+import io.ktor.server.config.MapApplicationConfig
+import io.ktor.server.response.respond
+import io.ktor.server.response.respondRedirect
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.ktor.server.sessions.Sessions
+import io.ktor.server.sessions.cookie
+import io.ktor.server.sessions.sessions
+import io.ktor.server.sessions.set
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import sh.zachwal.button.auth.CONTACT_SESSION_AUTH
+import sh.zachwal.button.session.CONTACT_SESSION
+import sh.zachwal.button.session.principals.ContactSessionPrincipal
+import java.time.Instant
+
+/**
+ * Lightweight Ktor integration test harness for contact-auth-gated routes.
+ *
+ * ## When to use
+ *
+ * Prefer unit tests (mockk) for pure logic and service-layer code. Use this harness only when
+ * the behavior under test lives inside the HTTP layer itself — form parsing, redirects, response
+ * codes, or auth gating — things that cannot be exercised without an actual request/response
+ * cycle. One test file per controller is a reasonable maximum.
+ *
+ * ## What it does
+ *
+ * - Suppresses `application.conf` module loading (which would install real DB-backed plugins).
+ * - Installs in-memory Sessions and a contact-session auth provider.
+ * - Mounts a `/test/set-session` GET endpoint that seeds a session for contact id [contactId].
+ * - Passes the configured [ApplicationTestBuilder] to your [block] so you can add routes,
+ *   create a client, and run assertions.
+ *
+ * ## Usage
+ *
+ * ```kotlin
+ * withContactTestApp(contactId = 1) {
+ *     routing { with(controller) { myRoute() } }
+ *     val client = createClient { install(HttpCookies) }
+ *     client.get("/test/set-session")
+ *     val response = client.post("/my-route") { ... }
+ *     assertEquals(HttpStatusCode.Found, response.status)
+ * }
+ * ```
+ */
+fun withContactTestApp(
+    contactId: Int = 1,
+    block: suspend ApplicationTestBuilder.() -> Unit,
+) = testApplication {
+    environment { config = MapApplicationConfig() }
+    application {
+        installContactTestPlugins(contactId)
+    }
+    block()
+}
+
+private fun Application.installContactTestPlugins(contactId: Int) {
+    install(Sessions) {
+        cookie<ContactSessionPrincipal>(CONTACT_SESSION)
+    }
+    install(Authentication) {
+        session<ContactSessionPrincipal>(CONTACT_SESSION_AUTH) {
+            validate { it.takeIf { p -> p.expiration > Instant.now().toEpochMilli() } }
+            challenge { call.respondRedirect("/") }
+        }
+    }
+    routing {
+        get("/test/set-session") {
+            call.sessions.set(
+                ContactSessionPrincipal(
+                    contactId = contactId,
+                    expiration = Instant.now().plusSeconds(3600).toEpochMilli()
+                )
+            )
+            call.respond(io.ktor.http.HttpStatusCode.OK)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **Phase 1a** (already merged): `notifications_enabled` DB column, `NotificationPreferences` model, `ContactDAO.updateNotificationPreferences()`
- **Phase 1b backend**: `ContactNotifier` filters out disabled contacts before sending SMS; `POST /contact/preferences` endpoint persists toggle
- **Phase 1b UI**: Contact settings page with notification toggle, saved-alert toast, contact info card
- **Code review fixes** (this commit): four issues caught in review

## Code review fixes applied

- `contactPreferences()` POST now returns 404 if `updateNotificationPreferences` returns null — prevents a false "Settings saved" response when the session's contact no longer exists in the DB
- Moved "Sending notification to contact" log from inside `filter {}` to the `forEach` that actually calls `sendMessage()`, so the log only fires when a send is attempted
- Removed redundant Bootstrap JS CDN `<script>` tag from the settings page
- Replaced `unsafe { +"&times;" }` with `+"×"` in `savedAlert()` to avoid unnecessarily disabling HTML escaping
- Extended `sharedhtml/Card.kt` with optional `cardBodyClasses` parameter (backward compatible); `contactInfoCard` and `notificationSettingsCard` now use the shared `card()` helper

## Note on Bootstrap JS

`headSetup()` loads Bootstrap CSS but not Bootstrap JS. Removing the explicit Bootstrap JS `<script>` tag means the `data-dismiss="alert"` close button and `alert.alert('close')` in `toast.js` currently have no Bootstrap JS to work with. The auto-dismiss toast will silently fail until Bootstrap JS is added to `headSetup()` or served locally. Worth following up.

## Test plan

- [ ] Visit `/contact` as a logged-in contact — settings page renders with contact info and notification toggle
- [ ] Toggle notifications off and click Save — redirected to `/contact?saved=true`, toast appears and dismisses after 3s
- [ ] Toggle back on — preference is persisted
- [ ] Confirm SMS is not sent to a contact with notifications disabled when the button is pressed
- [ ] `./gradlew test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)